### PR TITLE
fix(server): pass oldValue instead of property to correctBeanOptions

### DIFF
--- a/src/ru/biosoft/server/JSONUtils.java
+++ b/src/ru/biosoft/server/JSONUtils.java
@@ -291,7 +291,7 @@ public class JSONUtils
         }
         else
         {
-            correctBeanOptions(property, jsonObject.getJSONArray("value"), jsonOrder);
+            correctBeanOptions(oldValue, jsonObject.getJSONArray("value"), jsonOrder);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed a bug in `JSONUtils` where `correctBeanOptions` was being called with `property` (the property name string) instead of `oldValue` (the actual previous value).

**Change:** `src/ru/biosoft/server/JSONUtils.java:294`
- Before: `correctBeanOptions(property, ...)`
- After: `correctBeanOptions(oldValue, ...)`

This matches the pattern used in the `if` branch above, which already passes `oldValue`.