### PR TITLE
perf(profiler): optimize hot paths from async-profiler

### DIFF
--- a/src/ru/biosoft/access/ClassLoading.java
+++ b/src/ru/biosoft/access/ClassLoading.java
@@ -39,6 +39,10 @@ public class ClassLoading
 
     private static final Map<String, Bundle> packageToBundle = new ConcurrentHashMap<>();
 
+    // Cache for plugin ID lookup by class name to avoid repeated expensive lookups
+    // Only successful resolutions are cached (null values are not stored)
+    private static final Map<String, String> classNameToPlugin = new ConcurrentHashMap<>();
+
     static {
         initBundles();
         initMovedClasses();
@@ -359,6 +363,12 @@ public class ClassLoading
     {
         // First try plugins which names are package name substring
         Assert.notNull("className", className);
+
+        // Fast path: check the cache for previously resolved class names
+        String cachedPlugin = classNameToPlugin.get(className);
+        if( cachedPlugin != null )
+            return cachedPlugin;
+
         int pos = className.lastIndexOf( '.' );
         if(pos == -1)
         {
@@ -380,13 +390,16 @@ public class ClassLoading
         String packageName = className.substring( 0, pos );
         Bundle b = packageToBundle.get( packageName );
         if(b != null)
+        {
+            classNameToPlugin.put(className, b.getSymbolicName());
             return b.getSymbolicName();
+        }
         if(SecurityManager.isTestMode()) // no bundles in tests
             return null;
         //TODO: think about better solution.
         // We do not log warning, since java.lang classes are loaded automatically
         if( !packageName.startsWith( "java.lang" ) )
-        {   
+        {
             //log.log( Level.WARNING, "Unable to find cached bundle for class " + className + " using old path", new Exception() );
             log.log( Level.WARNING, "Unable to find cached bundle for class " + className + " using old path" );
         }
@@ -396,15 +409,20 @@ public class ClassLoading
         {
             pluginId = pluginId.substring(0, pluginNameEnd);
             if(tryLoad(className, pluginId) != null)
+            {
+                classNameToPlugin.put(className, pluginId);
                 return pluginId;
+            }
         }
         if(className.startsWith("ru.biosoft") && tryLoad(className, "ru.biosoft.workbench") != null)
         {
+            classNameToPlugin.put(className, "ru.biosoft.workbench");
             return "ru.biosoft.workbench";
         }
         //Then try biouml.workbench plugin
         if(tryLoad(className, "biouml.workbench") != null)
         {
+            classNameToPlugin.put(className, "biouml.workbench");
             return "biouml.workbench";
         }
         return null;

--- a/src/ru/biosoft/access/security/NetworkRepository.java
+++ b/src/ru/biosoft/access/security/NetworkRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -35,6 +36,9 @@ public class NetworkRepository extends FilteredDataCollection<DataCollection<?>>
 {
     public static final String PRODUCT_PROPERTY_PREFIX = "product.";
     private Map<String, Pattern> products;
+
+    // Cache for filtered name lists per session to avoid repeated permission checks
+    private final Map<String, List<String>> filteredNamesCache = new ConcurrentHashMap<>();
     
     public NetworkRepository(DataCollection<?> parent, Properties properties) throws Exception
     {
@@ -114,6 +118,12 @@ public class NetworkRepository extends FilteredDataCollection<DataCollection<?>>
     @Override
     protected List<String> getFilteredNames()
     {
+        // Check session-based cache first to avoid repeated permission checks
+        String sessionId = SecurityManager.getSession();
+        List<String> cached = filteredNamesCache.get(sessionId);
+        if( cached != null )
+            return cached;
+
         List<String> filteredNameList = new ArrayList<>();
         Filter filter = getFilter();
         for(DataCollection<?> dc : primaryCollection)
@@ -123,6 +133,8 @@ public class NetworkRepository extends FilteredDataCollection<DataCollection<?>>
                 filteredNameList.add(dc.getName());
             }
         }
+        // Cache the result for this session
+        filteredNamesCache.put(sessionId, filteredNameList);
         return filteredNameList;
     }
 

--- a/src/ru/biosoft/journal/JournalRegistry.java
+++ b/src/ru/biosoft/journal/JournalRegistry.java
@@ -26,6 +26,11 @@ public class JournalRegistry
     private static String currentJournalName = null;
     private static boolean useJournal = true;
 
+    // Cache for journal names to avoid repeated iteration over journal lists
+    private static volatile String[] cachedJournalNames = null;
+    private static volatile long journalNamesCacheTime = 0;
+    private static final long JOURNAL_NAMES_CACHE_TTL = 60_000; // 1 minute cache TTL
+
     /**
      * Special journal with empty functionality
      */
@@ -134,12 +139,24 @@ public class JournalRegistry
      */
     public static String[] getJournalNames()
     {
+        // Fast path: return cached result if still valid
+        long now = System.currentTimeMillis();
+        String[] cached = cachedJournalNames;
+        if( cached != null && (now - journalNamesCacheTime) < JOURNAL_NAMES_CACHE_TTL )
+        {
+            return cached;
+        }
+
+        // Slow path: recompute and cache
         List<String> result = new ArrayList<>();
         for( JournalList jl : journalLists )
         {
             result.addAll(jl.getNameList());
         }
-        return result.toArray(new String[result.size()]);
+        String[] names = result.toArray(new String[result.size()]);
+        cachedJournalNames = names;
+        journalNamesCacheTime = now;
+        return names;
     }
 
     public static Journal getJournalByPath(DataElementPath path)


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://ict.biouml.org (the server URL provided by the user).

## Profiles Analyzed
- Number of reports: 2
- Time range: last 24 hours
- Total samples across all profiles: 589 (application-level BioUML code)

## Top Hot Functions
1. WebServicesServlet.sendInitialInfo — 122 samples — Called on every login, makes 8+ sequential provider calls
2. ConnectionServlet.doPost — 153 samples — Request dispatch entry point
3. NetworkRepository.getFilteredNames — 71 samples — Calls SecurityManager.getPermissions() for every item during iteration
4. JournalRegistry.getJournalNames — 65 samples — Iterates all journal lists on every call
5. ClassLoading.loadClassFromPlugin — 21 samples — Repeated OSGi bundle lookups
6. ClassLoading.tryLoad — 16 samples — Class loading fallback path

## Changes
- **ClassLoading.getPluginForClass**: Added ConcurrentHashMap cache for plugin ID lookups by class name. Only successful resolutions are cached (null values not stored to avoid ConcurrentHashMap NPE). This eliminates repeated expensive OSGi bundle lookups for the same class.
- **NetworkRepository.getFilteredNames**: Added session-based cache for filtered name lists. Since permissions are already cached per-session in SecurityManager, the filtered name list can also be cached per-session, avoiding repeated iteration and permission checks.
- **JournalRegistry.getJournalNames**: Added time-based cache (60s TTL) for journal names list. Since journal configuration rarely changes, this avoids repeated iteration over journal lists on every initial info request.

## Verification
- [x] Maven build passes (mvn package -DskipTests)
- [x] Ant build passes (cd src && ant compile)
- [x] All tests pass (mvn -pl src test) — same result as baseline: 697 tests, 1 pre-existing failure (WorkflowTest), 0 errors

Co-Authored-By: Claude <noreply@anthropic.com>