### PR TITLE
perf(profiler): cache BioHub resolution results in hot workflow paths

### DIFF
--- a/src/ru/biosoft/access/biohub/BioHubRegistry.java
+++ b/src/ru/biosoft/access/biohub/BioHubRegistry.java
@@ -12,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,6 +29,7 @@ import ru.biosoft.access.DataCollectionListenerSupport;
 import ru.biosoft.access.core.DataCollection;
 import ru.biosoft.access.core.DataCollectionConfigConstants;
 import ru.biosoft.access.core.DataCollectionEvent;
+import ru.biosoft.access.core.DataCollectionListener;
 import ru.biosoft.access.core.DataCollectionVetoException;
 import ru.biosoft.access.core.DataElement;
 import ru.biosoft.access.core.DataElementPath;
@@ -320,8 +322,82 @@ public class BioHubRegistry extends ExtensionRegistrySupport<BioHubRegistry.BioH
             return true;
         if( !path.exists() )
             return false;
-        return addOtherVersions || ( projectPath == null && ProjectUtils.isDatabasePreferred( path ) )
-                || ProjectUtils.isDatabasePreferred( projectPath, path );
+        return addOtherVersions || ( projectPath == null && isDatabasePreferredCached( path ) )
+                || isDatabasePreferredCached( projectPath, path );
+    }
+
+    // Cached ProjectUtils.isDatabasePreferred results. The check resolves database
+    // element info (which goes through SecurityManager.getPermissions) and was
+    // executed for every BioHub on every getReachableTypes() call during workflow
+    // initialization. Values are invalidation-based: they expire when the databases
+    // collection changes (see ProjectUtils) or when permissions are reloaded.
+    private static final ConcurrentHashMap<DataElementPath, Boolean> preferredWithoutProject = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<DataElementPath, ConcurrentHashMap<DataElementPath, Boolean>> preferredByProject = new ConcurrentHashMap<>();
+    private static volatile DataCollectionListener preferredCheckListener;
+
+    private static void initPreferredCheckListener()
+    {
+        if( preferredCheckListener == null )
+        {
+            synchronized( BioHubRegistry.class )
+            {
+                if( preferredCheckListener == null )
+                {
+                    preferredCheckListener = new DataCollectionListenerSupport()
+                    {
+                        @Override
+                        public void elementAdded(DataCollectionEvent e)
+                        {
+                            clearPreferredCache();
+                        }
+
+                        @Override
+                        public void elementWillRemove(DataCollectionEvent e)
+                        {
+                            clearPreferredCache();
+                        }
+                    };
+                    CollectionFactoryUtils.getDatabases().addDataCollectionListener( preferredCheckListener );
+                }
+            }
+        }
+    }
+
+    /**
+     * Invalidate the cached isDatabasePreferred results (called from
+     * SecurityManager.invalidatePermissions, since permission changes can affect
+     * the result of the check).
+     */
+    public static void invalidatePreferredDatabaseCache()
+    {
+        clearPreferredCache();
+    }
+
+    private static void clearPreferredCache()
+    {
+        preferredWithoutProject.clear();
+        preferredByProject.clear();
+    }
+
+    private static boolean isDatabasePreferredCached(DataElementPath database)
+    {
+        return isDatabasePreferredCached( null, database );
+    }
+
+    private static boolean isDatabasePreferredCached(DataElementPath project, DataElementPath database)
+    {
+        initPreferredCheckListener();
+        ConcurrentHashMap<DataElementPath, Boolean> cache = project == null
+                ? preferredWithoutProject : preferredByProject.computeIfAbsent( project, p -> new ConcurrentHashMap<>() );
+        Boolean result = cache.get( database );
+        if( result == null )
+        {
+            result = project == null
+                    ? ProjectUtils.isDatabasePreferred( database )
+                    : ProjectUtils.isDatabasePreferred( project, database );
+            cache.put( database, result );
+        }
+        return result;
     }
 
     public static StreamEx<BioHubInfo> specialHubs()
@@ -487,7 +563,68 @@ public class BioHubRegistry extends ExtensionRegistrySupport<BioHubRegistry.BioH
         }
     }
 
+    // Cache of getMatchingGraph results. Building the graph iterates over all BioHubs
+    // and repeatedly calls getSupportedMatching; during workflow initialization the same
+    // input properties are requested for every node. Values are invalidation-based: they
+    // expire when the databases collection changes (hubs are added/removed).
+    private static final ConcurrentHashMap<Properties, List<MatchingStep>> matchingGraphCache = new ConcurrentHashMap<>();
+    private static volatile DataCollectionListener matchingGraphListener;
+
+    private static void initMatchingGraphListener()
+    {
+        if( matchingGraphListener == null )
+        {
+            synchronized( BioHubRegistry.class )
+            {
+                if( matchingGraphListener == null )
+                {
+                    matchingGraphListener = new DataCollectionListenerSupport()
+                    {
+                        @Override
+                        public void elementAdded(DataCollectionEvent e)
+                        {
+                            clearMatchingGraphCache();
+                        }
+
+                        @Override
+                        public void elementWillRemove(DataCollectionEvent e)
+                        {
+                            clearMatchingGraphCache();
+                        }
+                    };
+                    CollectionFactoryUtils.getDatabases().addDataCollectionListener( matchingGraphListener );
+                }
+            }
+        }
+    }
+
+    /**
+     * Invalidate the cached matching graphs (called from
+     * SecurityManager.invalidatePermissions, since permission changes can affect
+     * which BioHubs are available).
+     */
+    public static void invalidateMatchingGraphCache()
+    {
+        clearMatchingGraphCache();
+    }
+
+    private static void clearMatchingGraphCache()
+    {
+        matchingGraphCache.clear();
+    }
+
     private static List<MatchingStep> getMatchingGraph(Properties inputType)
+    {
+        initMatchingGraphListener();
+        List<MatchingStep> cached = matchingGraphCache.get( inputType );
+        if( cached != null )
+            return cached;
+        List<MatchingStep> steps = buildMatchingGraph( inputType );
+        List<MatchingStep> previous = matchingGraphCache.putIfAbsent( inputType, steps );
+        return previous != null ? previous : steps;
+    }
+
+    private static List<MatchingStep> buildMatchingGraph(Properties inputType)
     {
         List<MatchingStep> steps = new ArrayList<>();
         MatchingStep startStep = new MatchingStep( inputType );

--- a/src/ru/biosoft/access/security/SecurityManager.java
+++ b/src/ru/biosoft/access/security/SecurityManager.java
@@ -686,6 +686,13 @@ public class SecurityManager
      */
     public static void invalidatePermissions()
     {
+        // Permission changes can affect which databases are visible and which are
+        // preferred, so the cached database version list (ProjectUtils) and the
+        // cached isDatabasePreferred results (BioHubRegistry) must be refreshed.
+        ru.biosoft.journal.ProjectUtils.invalidateAvailableDatabaseVersions();
+        ru.biosoft.access.biohub.BioHubRegistry.invalidatePreferredDatabaseCache();
+        ru.biosoft.access.biohub.BioHubRegistry.invalidateMatchingGraphCache();
+
         //clear guest permissions map
         guestPermissionsMap.clear();
 

--- a/src/ru/biosoft/journal/ProjectUtils.java
+++ b/src/ru/biosoft/journal/ProjectUtils.java
@@ -12,8 +12,11 @@ import javax.annotation.CheckForNull;
 
 import one.util.streamex.StreamEx;
 import ru.biosoft.access.CollectionFactoryUtils;
+import ru.biosoft.access.DataCollectionListenerSupport;
 import ru.biosoft.access.DataCollectionUtils;
 import ru.biosoft.access.core.DataCollection;
+import ru.biosoft.access.core.DataCollectionEvent;
+import ru.biosoft.access.core.DataCollectionListener;
 import ru.biosoft.access.core.DataElementPath;
 import ru.biosoft.access.core.RepositoryException;
 import ru.biosoft.util.DatabaseVersionComparator;
@@ -149,13 +152,67 @@ public class ProjectUtils
     /**
      * @return map databaseMap -> set of available versions
      */
+    // Cache of getAvailableDatabaseVersions() results. The method scans all databases and
+    // re-resolves every database element on each call (each resolution goes through
+    // SecurityManager.getPermissions). The list of installed databases rarely changes during
+    // a server run, while the method is called from hot paths
+    // (BioHubRegistry.isHubPathAvailable, ProjectUtils.isDatabasePreferred) for every
+    // BioHub on every workflow initialization. The cache is invalidation-based: it is
+    // refreshed whenever the databases collection changes or permissions are reloaded.
+    private static volatile Map<String, SortedSet<String>> availableDatabaseVersions;
+    private static volatile DataCollectionListener availableVersionsListener;
+
+    private static void initAvailableVersionsListener()
+    {
+        if( availableVersionsListener == null )
+        {
+            synchronized( ProjectUtils.class )
+            {
+                if( availableVersionsListener == null )
+                {
+                    availableVersionsListener = new DataCollectionListenerSupport()
+                    {
+                        @Override
+                        public void elementAdded(DataCollectionEvent e)
+                        {
+                            availableDatabaseVersions = null;
+                        }
+
+                        @Override
+                        public void elementWillRemove(DataCollectionEvent e)
+                        {
+                            availableDatabaseVersions = null;
+                        }
+                    };
+                    CollectionFactoryUtils.getDatabases().addDataCollectionListener( availableVersionsListener );
+                }
+            }
+        }
+    }
+
+    /**
+     * Invalidate the cache of available database versions (called from
+     * SecurityManager.invalidatePermissions, since permission changes can affect
+     * which databases are visible).
+     */
+    public static void invalidateAvailableDatabaseVersions()
+    {
+        availableDatabaseVersions = null;
+    }
+
     public static Map<String, SortedSet<String>> getAvailableDatabaseVersions()
     {
-        return StreamEx.of( CollectionFactoryUtils.getDatabases().stream() )
+        Map<String, SortedSet<String>> versions = availableDatabaseVersions;
+        if( versions != null )
+            return versions;
+        initAvailableVersionsListener();
+        versions = StreamEx.of( CollectionFactoryUtils.getDatabases().stream() )
                 .mapToEntry( ProjectUtils::getDatabaseName, ProjectUtils::getVersion )
                 .nonNullKeys().removeValues( String::isEmpty ).groupingTo( TreeMap::new, () -> {
                     return new TreeSet<>( new DatabaseVersionComparator() );
                 } );
+        availableDatabaseVersions = versions;
+        return versions;
     }
 
     public static Map<String, String> getPreferredDatabaseVersions(DataElementPath project)

--- a/src/ru/biosoft/util/DatabaseVersionComparator.java
+++ b/src/ru/biosoft/util/DatabaseVersionComparator.java
@@ -3,6 +3,7 @@ package ru.biosoft.util;
 import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * Comparator for database versions. 
@@ -12,14 +13,31 @@ import java.util.regex.Pattern;
  */
 public class DatabaseVersionComparator implements Comparator<String>
 {
-    private Pattern p = Pattern.compile( "^(\\d+(?:\\.\\d+))" );
+    // Pattern is compiled once and shared by all comparator instances (previously
+    // every instance recompiled the same regular expression).
+    private static final Pattern PATTERN = compilePattern();
+
+    private static Pattern compilePattern()
+    {
+        try
+        {
+            return Pattern.compile( "^(\\d+(?:\\.\\d+))" );
+        }
+        catch( PatternSyntaxException e )
+        {
+            // Should never happen with the literal pattern above; fall back to a pattern
+            // which matches nothing so that compare() degrades to plain string comparison.
+            return Pattern.compile( "^$" );
+        }
+    }
+
     @Override
     public int compare(String o1, String o2)
     {
         try
         {
-            Matcher m1 = p.matcher( o1 );
-            Matcher m2 = p.matcher( o2 );
+            Matcher m1 = PATTERN.matcher( o1 );
+            Matcher m2 = PATTERN.matcher( o2 );
             if( m1.find() && m2.find() )
             {
                 String d1s = m1.group( 1 );


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://strange.genexplain.com (the server URL provided by the user).

## Profiles Analyzed
- Number of reports: 3
- Time range: last 24 hours (2026-08-20 10:13–10:48)
- Total samples across all profiles: 5509
- Dominant task: workflow recovery/init (2026.08.20 10:44:42 3), ~2116 samples through WorkflowEngine.getAnalysisParametersByNode

## Top Hot Functions
1. WorkflowEngine.getAnalysisParametersByNode — 4165 samples (total) / 2116 (recovery chain) — reads analysis parameters for every workflow node during init/checkModel
2. SecurityManager.getPermissions — 2979 samples — synchronized permission lookup reached on every database element resolution
3. ProjectUtils.isDatabasePreferred — 2746 samples — per-BioHub preferred-version check
4. ProjectUtils.getAvailableDatabaseVersions — 2326 samples — re-scanned all databases on every call
5. BioHubRegistry.isHubPathAvailable / getMatchingGraph — 1833 / 2051 samples — per-hub availability + full matching-graph rebuild

## Changes
- ProjectUtils: cache getAvailableDatabaseVersions() results; invalidated by a DataCollectionListener on the databases collection and by SecurityManager.invalidatePermissions()
- BioHubRegistry: cache ProjectUtils.isDatabasePreferred results (with and without project) and getMatchingGraph results; same invalidation strategy
- SecurityManager.invalidatePermissions(): now also refreshes both caches, since permission changes affect which databases are visible/preferred
- DatabaseVersionComparator: share one statically compiled Pattern instead of compiling it per comparator instance

All caches are invalidation-based (collection-change listener + permission reload), not time-based, so no stale-data window.

## Verification
- [x] Maven build passes (mvn package -DskipTests)
- [x] Ant build passes (cd src && ant compile)
- [x] All tests pass (mvn -pl src test — 697 tests, 0 failures)

Co-Authored-By: Claude <noreply@anthropic.com>