### PR TITLE
perf(profiler): optimize hot paths from async-profiler (db versions, security fast path)

### DIFF
--- a/src/ru/biosoft/access/security/SecurityManager.java
+++ b/src/ru/biosoft/access/security/SecurityManager.java
@@ -66,9 +66,12 @@ public class SecurityManager
 
     private static final Map<String, Integer> guestPermissionsMap = new WeakHashMap<>();
 
-    private static SecurityProvider securityProvider = null;
+    // volatile: getPermissions() reads these outside the class monitor (fast path), so they
+    // must be safely published for the writes in initSecurityManager() to be visible to all
+    // threads.
+    private static volatile SecurityProvider securityProvider = null;
 
-    private static String adminSession = null;
+    private static volatile String adminSession = null;
 
     private static boolean isThreadPrivileged()
     {

--- a/src/ru/biosoft/access/security/SecurityManager.java
+++ b/src/ru/biosoft/access/security/SecurityManager.java
@@ -130,60 +130,76 @@ public class SecurityManager
      * Get permissions by collection name and properties if necessary
      * @param create create guest permissions automatically if not logged in
      */
-    protected static synchronized Permission getPermissions(String dataCollectionName, boolean create)
+    protected static Permission getPermissions(String dataCollectionName, boolean create)
     {
-        if(securityProvider == null || Thread.currentThread().getName().equals("Finalizer") || isThreadPrivileged())    // Bypass security check for Finalizer
+        // Fast path: bypass the security check for privileged threads and Finalizer without
+        // taking the class monitor (the old synchronized method made every permission check a
+        // global lock, which dominated CPU time in the hot workflow initialization paths).
+        if( securityProvider == null || Thread.currentThread().getName().equals("Finalizer") || isThreadPrivileged() )    // Bypass security check for Finalizer
         {
             return PRIVILEGED_PERMISSION;
         }
         String sessionId = getSession();
-        if(adminSession != null && adminSession.equals(sessionId))
+        if( adminSession != null && adminSession.equals(sessionId) )
             return PRIVILEGED_PERMISSION;
-        long currentTime = System.currentTimeMillis();
-        if( !sessionId.equals(SYSTEM_SESSION) )
-        {
-            UserPermissions ps = sessionToPermission.get(sessionId);
-            if( ps == null )
-            {
-                if(!create)
-                    return null;
-                ps = new UserPermissions("", "");
-                sessionToPermission.put(sessionId, ps);
-            }
-            ps.updateExpirationTime();
-            Permission permission = null;
-
-            Hashtable<String, Permission> dbToPermission = ps.getDbToPermission();
-            synchronized( dbToPermission )
-            {
-                if( dbToPermission.containsKey(dataCollectionName) )
-                {
-                    Permission p = dbToPermission.get(dataCollectionName);
-                    if( p.getExpirationTime() > currentTime )
-                    {
-                        permission = p;
-                    }
-                    else
-                    {
-                        dbToPermission.remove(dataCollectionName);
-                    }
-                }
-
-                if( permission == null )
-                {
-                    permission = authorize(dataCollectionName, ps, sessionId);
-                    dbToPermission.put(dataCollectionName, permission);
-                }
-            }
-            if(permission.getSessionId() == null || permission.getSessionId().isEmpty())
-            {
-                permission = new Permission(permission.getPermissions(), permission.getUserName(), sessionId, permission.getExpirationTime());
-            }
-            return permission;
-        }
-        if(!create)
+        if( sessionId.equals(SYSTEM_SESSION) && !create )
             return null;
+        if( !sessionId.equals(SYSTEM_SESSION) )
+            return getUserPermission( sessionId, dataCollectionName, create );
+        return getGuestPermission( dataCollectionName );
+    }
 
+    // Per-user permission resolution. Synchronized on this class: the sessionToPermission map
+    // and the per-user dbToPermission Hashtable are shared mutable state, and this method may
+    // add new entries to both.
+    private static synchronized Permission getUserPermission(String sessionId, String dataCollectionName, boolean create)
+    {
+        long currentTime = System.currentTimeMillis();
+        UserPermissions ps = sessionToPermission.get(sessionId);
+        if( ps == null )
+        {
+            if(!create)
+                return null;
+            ps = new UserPermissions("", "");
+            sessionToPermission.put(sessionId, ps);
+        }
+        ps.updateExpirationTime();
+        Permission permission = null;
+
+        Hashtable<String, Permission> dbToPermission = ps.getDbToPermission();
+        synchronized( dbToPermission )
+        {
+            if( dbToPermission.containsKey(dataCollectionName) )
+            {
+                Permission p = dbToPermission.get(dataCollectionName);
+                if( p.getExpirationTime() > currentTime )
+                {
+                    permission = p;
+                }
+                else
+                {
+                    dbToPermission.remove(dataCollectionName);
+                }
+            }
+
+            if( permission == null )
+            {
+                permission = authorize(dataCollectionName, ps, sessionId);
+                dbToPermission.put(dataCollectionName, permission);
+            }
+        }
+        if(permission.getSessionId() == null || permission.getSessionId().isEmpty())
+        {
+            permission = new Permission(permission.getPermissions(), permission.getUserName(), sessionId, permission.getExpirationTime());
+        }
+        return permission;
+    }
+
+    // Guest (anonymous) permission resolution. Synchronized on this class to keep
+    // guestPermissionsMap access consistent with the rest of the security state.
+    private static synchronized Permission getGuestPermission(String dataCollectionName)
+    {
+        long currentTime = System.currentTimeMillis();
         Integer guestPermissions = guestPermissionsMap.get(dataCollectionName);
         if( guestPermissions == null )
         {

--- a/src/ru/biosoft/journal/ProjectUtils.java
+++ b/src/ru/biosoft/journal/ProjectUtils.java
@@ -170,6 +170,12 @@ public class ProjectUtils
     private static volatile Map<String, SortedSet<String>> availableDatabaseVersions;
     private static final AtomicLong availableVersionsGeneration = new AtomicLong();
     private static volatile DataCollectionListener availableVersionsListener;
+    // The resolved "databases" collection. Resolving it goes through
+    // SecurityManager.getPermissions (a synchronized call), and buildAvailableDatabaseVersions
+    // used to re-resolve it on every rebuild. The collection object itself is stable (only its
+    // contents change), so it is cached here and refreshed when the databases change or
+    // permissions are reloaded — both of which already invalidate the versions cache.
+    private static volatile DataCollection<DataCollection<?>> databasesCollection;
 
     private static void initAvailableVersionsListener()
     {
@@ -193,7 +199,8 @@ public class ProjectUtils
                             invalidateAvailableDatabaseVersions();
                         }
                     };
-                    CollectionFactoryUtils.getDatabases().addDataCollectionListener( availableVersionsListener );
+                    databasesCollection = CollectionFactoryUtils.getDatabases();
+                    databasesCollection.addDataCollectionListener( availableVersionsListener );
                 }
             }
         }
@@ -210,6 +217,9 @@ public class ProjectUtils
     {
         availableVersionsGeneration.incrementAndGet();
         availableDatabaseVersions = null;
+        // The databases collection is resolved through security; after a permission reload
+        // (or a databases change) re-resolve it on the next build.
+        databasesCollection = null;
     }
 
     public static Map<String, SortedSet<String>> getAvailableDatabaseVersions()
@@ -231,7 +241,13 @@ public class ProjectUtils
     private static Map<String, SortedSet<String>> buildAvailableDatabaseVersions()
     {
         TreeMap<String, SortedSet<String>> result = new TreeMap<>();
-        StreamEx.of( CollectionFactoryUtils.getDatabases().stream() )
+        DataCollection<DataCollection<?>> databases = databasesCollection;
+        if( databases == null )
+        {
+            databases = CollectionFactoryUtils.getDatabases();
+            databasesCollection = databases;
+        }
+        StreamEx.of( databases.stream() )
                 .mapToEntry( ProjectUtils::getDatabaseName, ProjectUtils::getVersion )
                 .nonNullKeys().removeValues( String::isEmpty ).groupingTo( TreeMap::new, () -> {
                     return new TreeSet<>( new DatabaseVersionComparator() );

--- a/src/ru/biosoft/util/DatabaseVersionComparator.java
+++ b/src/ru/biosoft/util/DatabaseVersionComparator.java
@@ -12,9 +12,12 @@ public class DatabaseVersionComparator implements Comparator<String>
 {
     // Maximum number of fractional digits taken into account. Beyond this the values are
     // indistinguishable for any practical version string, and 15 is the last width where a
-    // scaled long value cannot overflow (10^15 * 10 < 2^63).
+    // scaled long value cannot overflow (10^15 * 10 < 2^63). Digits beyond this are dropped
+    // while parsing (so the accumulator can never overflow).
     private static final int MAX_FRACTION_DIGITS = 15;
-    private static final long TRUNCATION_MODULUS = 1000000000000000L;
+    // Maximum number of integer digits accumulated before dropping the rest (18 is the last
+    // width where value * 10 + 9 cannot overflow a long).
+    private static final int MAX_INTEGER_DIGITS = 18;
 
     @Override
     public int compare(String o1, String o2)
@@ -29,9 +32,13 @@ public class DatabaseVersionComparator implements Comparator<String>
         int i2 = parseNumber( o2 );
         if( i1 > 0 && i2 > 0 )
         {
-            // Parse integer and fractional digit values separately (e.g. "52.36" -> int 52, frac 36)
+            // Parse integer and fractional digit values separately (e.g. "52.36" -> int 52, frac 36).
+            // Digits beyond MAX_*_DIGITS are dropped while parsing so the accumulators cannot
+            // overflow (real version strings are far shorter; the old Double-based code would
+            // lose precision or saturate on such inputs, never reverse direction).
             long intPart1 = 0, intPart2 = 0;
             long fracPart1 = 0, fracPart2 = 0;
+            int intDigits1 = 0, intDigits2 = 0;
             int fracDigits1 = 0, fracDigits2 = 0;
             boolean d1 = false, d2 = false;
             for( int i = 0; i < i1; i++ )
@@ -44,12 +51,19 @@ public class DatabaseVersionComparator implements Comparator<String>
                 }
                 if( d1 )
                 {
-                    fracPart1 = fracPart1 * 10 + ( c - '0' );
-                    fracDigits1++;
+                    if( fracDigits1 < MAX_FRACTION_DIGITS )
+                    {
+                        fracPart1 = fracPart1 * 10 + ( c - '0' );
+                        fracDigits1++;
+                    }
                 }
                 else
                 {
-                    intPart1 = intPart1 * 10 + ( c - '0' );
+                    if( intDigits1 < MAX_INTEGER_DIGITS )
+                    {
+                        intPart1 = intPart1 * 10 + ( c - '0' );
+                        intDigits1++;
+                    }
                 }
             }
             for( int i = 0; i < i2; i++ )
@@ -62,12 +76,19 @@ public class DatabaseVersionComparator implements Comparator<String>
                 }
                 if( d2 )
                 {
-                    fracPart2 = fracPart2 * 10 + ( c - '0' );
-                    fracDigits2++;
+                    if( fracDigits2 < MAX_FRACTION_DIGITS )
+                    {
+                        fracPart2 = fracPart2 * 10 + ( c - '0' );
+                        fracDigits2++;
+                    }
                 }
                 else
                 {
-                    intPart2 = intPart2 * 10 + ( c - '0' );
+                    if( intDigits2 < MAX_INTEGER_DIGITS )
+                    {
+                        intPart2 = intPart2 * 10 + ( c - '0' );
+                        intDigits2++;
+                    }
                 }
             }
             // Compare integer parts first; scale fractional parts to a common width before
@@ -75,16 +96,6 @@ public class DatabaseVersionComparator implements Comparator<String>
             int cmp = Long.compare( intPart1, intPart2 );
             if( cmp == 0 )
             {
-                if( fracDigits1 > MAX_FRACTION_DIGITS )
-                {
-                    fracPart1 = fracPart1 % TRUNCATION_MODULUS;
-                    fracDigits1 = MAX_FRACTION_DIGITS;
-                }
-                if( fracDigits2 > MAX_FRACTION_DIGITS )
-                {
-                    fracPart2 = fracPart2 % TRUNCATION_MODULUS;
-                    fracDigits2 = MAX_FRACTION_DIGITS;
-                }
                 while( fracDigits1 < fracDigits2 )
                 {
                     fracPart1 *= 10;

--- a/src/ru/biosoft/util/DatabaseVersionComparator.java
+++ b/src/ru/biosoft/util/DatabaseVersionComparator.java
@@ -1,57 +1,142 @@
 package ru.biosoft.util;
 
 import java.util.Comparator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 /**
- * Comparator for database versions. 
+ * Comparator for database versions.
  * Version is supposed to be <number>[.<number>[some symbols]], for example: 52.36n or 2020.3
  * Compare numerical parts as doubles. If numerical parts are equal, then compare as strings.
  * @author anna
  */
 public class DatabaseVersionComparator implements Comparator<String>
 {
-    // Pattern is compiled once and shared by all comparator instances (previously
-    // every instance recompiled the same regular expression).
-    private static final Pattern PATTERN = compilePattern();
-
-    private static Pattern compilePattern()
-    {
-        try
-        {
-            return Pattern.compile( "^(\\d+(?:\\.\\d+))" );
-        }
-        catch( PatternSyntaxException e )
-        {
-            // Should never happen with the literal pattern above; fall back to a pattern
-            // which matches nothing so that compare() degrades to plain string comparison.
-            return Pattern.compile( "^$" );
-        }
-    }
+    // Maximum number of fractional digits taken into account. Beyond this the values are
+    // indistinguishable for any practical version string, and 15 is the last width where a
+    // scaled long value cannot overflow (10^15 * 10 < 2^63).
+    private static final int MAX_FRACTION_DIGITS = 15;
+    private static final long TRUNCATION_MODULUS = 1000000000000000L;
 
     @Override
     public int compare(String o1, String o2)
     {
-        try
+        // The numerical prefix format is <digits>.<digits> — parse it directly instead of
+        // going through Pattern/Matcher/Double (this comparator runs inside TreeSet operations
+        // while scanning all database versions, so it is on a hot path). The parse below is
+        // allocation-free and equivalent to the old ^(\\d+(?:\\.\\d+)) regex match: a match
+        // requires a decimal point with digits after it, and an empty prefix means "no match"
+        // exactly as Matcher.find() == false (e.g. "52" has no match, "52.36n" -> "52.36").
+        int i1 = parseNumber( o1 );
+        int i2 = parseNumber( o2 );
+        if( i1 > 0 && i2 > 0 )
         {
-            Matcher m1 = PATTERN.matcher( o1 );
-            Matcher m2 = PATTERN.matcher( o2 );
-            if( m1.find() && m2.find() )
+            // Parse integer and fractional digit values separately (e.g. "52.36" -> int 52, frac 36)
+            long intPart1 = 0, intPart2 = 0;
+            long fracPart1 = 0, fracPart2 = 0;
+            int fracDigits1 = 0, fracDigits2 = 0;
+            boolean d1 = false, d2 = false;
+            for( int i = 0; i < i1; i++ )
             {
-                String d1s = m1.group( 1 );
-                String d2s = m2.group( 1 );
-                Double d1 = Double.parseDouble( d1s );
-                Double d2 = Double.parseDouble( d2s );
-                int cmp = d1.compareTo( d2 );
-                if( cmp != 0 || ( d1s.length() == o1.length() && d2s.length() == o2.length() ) )
-                    return cmp;
+                char c = o1.charAt( i );
+                if( c == '.' )
+                {
+                    d1 = true;
+                    continue;
+                }
+                if( d1 )
+                {
+                    fracPart1 = fracPart1 * 10 + ( c - '0' );
+                    fracDigits1++;
+                }
+                else
+                {
+                    intPart1 = intPart1 * 10 + ( c - '0' );
+                }
             }
-        }
-        catch( NullPointerException | NumberFormatException ex )
-        {
+            for( int i = 0; i < i2; i++ )
+            {
+                char c = o2.charAt( i );
+                if( c == '.' )
+                {
+                    d2 = true;
+                    continue;
+                }
+                if( d2 )
+                {
+                    fracPart2 = fracPart2 * 10 + ( c - '0' );
+                    fracDigits2++;
+                }
+                else
+                {
+                    intPart2 = intPart2 * 10 + ( c - '0' );
+                }
+            }
+            // Compare integer parts first; scale fractional parts to a common width before
+            // comparing them (e.g. 52.3 vs 52.30 -> 30 vs 30).
+            int cmp = Long.compare( intPart1, intPart2 );
+            if( cmp == 0 )
+            {
+                if( fracDigits1 > MAX_FRACTION_DIGITS )
+                {
+                    fracPart1 = fracPart1 % TRUNCATION_MODULUS;
+                    fracDigits1 = MAX_FRACTION_DIGITS;
+                }
+                if( fracDigits2 > MAX_FRACTION_DIGITS )
+                {
+                    fracPart2 = fracPart2 % TRUNCATION_MODULUS;
+                    fracDigits2 = MAX_FRACTION_DIGITS;
+                }
+                while( fracDigits1 < fracDigits2 )
+                {
+                    fracPart1 *= 10;
+                    fracDigits1++;
+                }
+                while( fracDigits2 < fracDigits1 )
+                {
+                    fracPart2 *= 10;
+                    fracDigits2++;
+                }
+                cmp = Long.compare( fracPart1, fracPart2 );
+            }
+            // Same rule as before: if the numerical parts differ, that decides; if they are
+            // equal but the strings have trailing symbols (e.g. "52.36n"), fall back to the
+            // plain string comparison.
+            if( cmp != 0 || ( i1 == o1.length() && i2 == o2.length() ) )
+                return cmp;
         }
         return o1.compareTo( o2 );
+    }
+
+    /**
+     * Length of the leading <digits>.<digits> prefix of s (0 if s does not contain a
+     * decimal point with digits after it — the same condition under which the old
+     * regex Matcher.find() returned false).
+     */
+    private static int parseNumber(String s)
+    {
+        int len = s.length();
+        int i = 0;
+        while( i < len )
+        {
+            char c = s.charAt( i );
+            if( c < '0' || c > '9' )
+                break;
+            i++;
+        }
+        if( i == 0 )
+            return 0;
+        if( i < len && s.charAt( i ) == '.' )
+        {
+            int j = i + 1;
+            while( j < len )
+            {
+                char c = s.charAt( j );
+                if( c < '0' || c > '9' )
+                    break;
+                j++;
+            }
+            if( j > i + 1 )
+                return j;
+        }
+        return 0;
     }
 }

--- a/src/ru/biosoft/util/_test/DatabaseVersionComparatorTest.java
+++ b/src/ru/biosoft/util/_test/DatabaseVersionComparatorTest.java
@@ -52,7 +52,7 @@ public class DatabaseVersionComparatorTest extends TestCase
         // Equal numerical parts with trailing symbols -> string comparison
         assertOrder( "52.36", "52.361" );
         assertOrder( "52.36n", "52.361" );
-        // 'a' (0x61) sorts after '(' (0x28) in the string fallback
+        // ' ' (0x20, the char after "75.13") sorts before 'a' (0x61) in the string fallback
         assertOrder( "75.13 (homo_sapiens)", "75.13a" );
         // A version with trailing symbols compares to another version by its numerical part
         assertOrder( "52.36n", "107.1" );
@@ -63,6 +63,20 @@ public class DatabaseVersionComparatorTest extends TestCase
         // no numerical part at all on both sides -> plain (case-sensitive) string comparison
         assertOrder( "Ensembl 75", "abc" );
         assertOrder( "52abc", "75 Ensembl" );
+    }
+
+    public void testLongDigitRunsDoNotOverflow()
+    {
+        // Fractional and integer digit runs longer than the tracked width must not throw and
+        // must not reverse the comparison direction (extra digits are dropped while parsing).
+        String longFrac = "1." + "1234567890123456789012345";
+        String longInt = "999999999999999999999999.1";
+        // a very large integer part still compares greater than a small one, in both directions
+        assertTrue( comparator.compare( longInt, "1.0" ) > 0 );
+        assertTrue( comparator.compare( "1.0", longInt ) < 0 );
+        // a very long fractional part compares without throwing
+        comparator.compare( longFrac, "1.0" );
+        comparator.compare( "1.0", longFrac );
     }
 
     public void testFullSorting()

--- a/src/ru/biosoft/util/_test/DatabaseVersionComparatorTest.java
+++ b/src/ru/biosoft/util/_test/DatabaseVersionComparatorTest.java
@@ -1,0 +1,84 @@
+package ru.biosoft.util._test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import ru.biosoft.util.DatabaseVersionComparator;
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link DatabaseVersionComparator}. The comparator is used to order database
+ * versions (like "52.36n" or "2020.3"): numerical parts are compared as numbers, and if
+ * they are equal (or one version has no numerical part) the plain string comparison is used.
+ */
+public class DatabaseVersionComparatorTest extends TestCase
+{
+    private final DatabaseVersionComparator comparator = new DatabaseVersionComparator();
+
+    private void assertOrder(String lower, String higher)
+    {
+        assertTrue( "Expected " + lower + " < " + higher, comparator.compare( lower, higher ) < 0 );
+        assertTrue( "Expected " + higher + " > " + lower, comparator.compare( higher, lower ) > 0 );
+    }
+
+    public void testIntegerParts()
+    {
+        assertOrder( "52.36", "107.1" );
+        assertOrder( "75.13", "100.1" );
+        assertOrder( "999.1", "1000.1" );
+        assertOrder( "3.0", "10.0" );
+    }
+
+    public void testFractionalParts()
+    {
+        assertOrder( "52.36", "52.4" );
+        assertOrder( "75.13", "75.14" );
+        // trailing zeros in the fractional part do not change the value
+        assertEquals( 0, Integer.signum( comparator.compare( "52.30", "52.3" ) ) );
+    }
+
+    public void testNoDecimalPartFallsBackToString()
+    {
+        // A version without a decimal part has no numerical match and is compared as a string
+        assertOrder( "3", "52.36" );
+        assertOrder( "52", "999" );
+        assertOrder( "107", "2020" );
+    }
+
+    public void testTrailingSymbols()
+    {
+        // Equal numerical parts with trailing symbols -> string comparison
+        assertOrder( "52.36", "52.361" );
+        assertOrder( "52.36n", "52.361" );
+        // 'a' (0x61) sorts after '(' (0x28) in the string fallback
+        assertOrder( "75.13 (homo_sapiens)", "75.13a" );
+        // A version with trailing symbols compares to another version by its numerical part
+        assertOrder( "52.36n", "107.1" );
+    }
+
+    public void testNonNumericVersions()
+    {
+        // no numerical part at all on both sides -> plain (case-sensitive) string comparison
+        assertOrder( "Ensembl 75", "abc" );
+        assertOrder( "52abc", "75 Ensembl" );
+    }
+
+    public void testFullSorting()
+    {
+        List<String> versions = Arrays.asList(
+                "0", "0.0", "0.1", "1.1", "1.10", "1.2", "100.1", "1000.1", "101.1",
+                "106.9", "107.1", "112.1", "113.1", "2.0", "2020.3", "3.0", "52.3",
+                "52.30", "52.36", "52.36n", "52.361", "106.1", "75.13",
+                "75.13 (homo_sapiens)", "75.1", "999.1" );
+        List<String> sorted = new ArrayList<>( versions );
+        Collections.sort( sorted, comparator );
+        List<String> expected = Arrays.asList(
+                "0", "0.0", "0.1", "1.1", "1.10", "1.2", "2.0", "3.0", "52.3",
+                "52.30", "52.36", "52.36n", "52.361", "75.1", "75.13",
+                "75.13 (homo_sapiens)", "100.1", "101.1", "106.1", "106.9",
+                "107.1", "112.1", "113.1", "999.1", "1000.1", "2020.3" );
+        assertEquals( expected, sorted );
+    }
+}


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://strange.genexplain.com (the server URL provided by the user).

## Profiles Analyzed
- Number of reports: 4 (of 6 listed; 2 were <30 samples)
- Time range: last 24 hours
- Total samples across all profiles: 5792
- Dominant profile: profile_1787218068382 (5008 samples, triggered by a genome-enhancer mega-workflow generation task)

## Top Hot Functions
1. `__pv_queued_spin_lock_slowpath` / `ObjectMonitor::enter` + `TrySpin` — 475+357 samples (~18%) — global lock contention from `SecurityManager.getPermissions` (synchronized)
2. `java/util/Hashtable.get` — 249 samples (~5%) — per-call permission lookup inside the synchronized block
3. `java/util/regex/Matcher.find` / `Pattern.*.match` — 105+49+46 samples (~6%) — `DatabaseVersionComparator.compare` run inside TreeSet operations
4. `jdk/internal/math/FloatingDecimal.parseDouble` — 73+60 samples (~3%) — `Double.parseDouble` per compare
5. `ru/biosoft/access/core/DataElementPath.getChildPath` — 40 samples — per-element path re-resolution in the databases scan
6. `ru/biosoft/access/LocalRepository.get` — 35 samples — per-element security resolution

## Root Cause
`ProjectUtils.getAvailableDatabaseVersions` (46% of the profile) → `isDatabasePreferred` →
`SecurityManager.getPermissions` (synchronized on the class) for **every database element on
every rebuild**. The existing caches (PR #23) make the steady state cheap, but every rebuild
re-resolves the whole databases collection and every permission check serialized all threads
on one monitor.

## Changes
- **SecurityManager.getPermissions** — moved the privileged-thread/Finalizer bypass and the
  admin-session check **out** of the synchronized method, so privileged threads (the common
  case in workflow initialization) never take the class monitor. Per-user and guest resolution
  split into private synchronized helpers with identical semantics and locking.
- **DatabaseVersionComparator** — replaced per-compare `Pattern`/`Matcher`/`Double` with an
  allocation-free parse of the `<digits>.<digits>` prefix. Semantics preserved exactly,
  including the original quirk that a version **without** a decimal part has no numerical
  match and falls back to string comparison (diff-tested against the original on all realistic
  version strings; only pathological >15-digit fractions differ).
- **ProjectUtils** — cache the resolved `databases` collection (its resolution goes through
  `SecurityManager.getPermissions`); refreshed on the same invalidation events as the versions
  cache (databases added/removed, permission reload).

## Verification
- [x] Maven build passes (`mvn package -DskipTests`)
- [x] Ant build passes (`cd src && ant compile`)
- [x] All tests pass (`mvn -pl src test` — 708 tests, 0 failures)
- [x] New `DatabaseVersionComparatorTest` (6 tests) covers integer/fractional parts, trailing
  symbols, non-numeric versions, and full sorting

Co-Authored-By: Claude <noreply@anthropic.com>