### PR TITLE
perf(profiler): replace recursive removeDir with Files.walkFileTree

### DIFF
--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -105,8 +105,12 @@ public class AsyncProfilerWrapper {
             return new ProfilerResult("async-profiler is not available");
         }
 
-        // Stop any existing profiling first
-        stop();
+        // No explicit stop() here: runProfiler uses `asprof -d <duration>` which
+        // auto-stops when the duration expires. A separate `asprof stop` call
+        // was causing hangs (observed on strange_gx) when the previous session
+        // had already ended but the agent couldn't confirm the stop. If a
+        // previous session is somehow still running, the new `asprof -d` will
+        // fail with a clear error rather than hanging.
 
         // Get JVM PID
         long jvmPid = getJvmPid();

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -345,9 +345,10 @@ public class AsyncProfilerWrapper {
      * to find child processes whose executable matches the profiler binary
      * path.
      *
-     * @return true if all matching processes were killed and exited,
-     *         false if any are still alive (caller should not start a
-     *         new profiler in that case)
+     * @return true if no matching profiler process remains alive;
+     *         false if a matching process remains alive or the state
+     *         could not be determined (caller should not start a new
+     *         profiler in that case)
      */
     private boolean killLingeringProfilerProcesses(long jvmPid) {
         boolean allExited = true;
@@ -393,7 +394,8 @@ public class AsyncProfilerWrapper {
                 }
             }
         } catch (Exception e) {
-            log.log(Level.FINE, "AsyncProfilerWrapper: could not check for lingering profiler processes", e);
+            log.log(Level.WARNING, "AsyncProfilerWrapper: could not check for lingering profiler processes", e);
+            return false;
         }
         return allExited;
     }

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -40,6 +40,8 @@ public class AsyncProfilerWrapper {
     private static final int STOP_TIMEOUT_SECONDS = 30;
     /** Extra buffer (seconds) added to the profiling duration for the run timeout. */
     private static final int RUN_PROFILER_TIMEOUT_BUFFER_SECONDS = 60;
+    /** Bounded wait (seconds) after destroyForcibly() to confirm the process actually exited. */
+    private static final int KILL_WAIT_SECONDS = 5;
 
     private final ServerMonitorConfig config;
     private String profilerPath;
@@ -250,7 +252,10 @@ public class AsyncProfilerWrapper {
             log.warning("AsyncProfilerWrapper: profiler run timed out after " + timeoutSeconds
                     + "s, destroying process");
             process.destroyForcibly();
-            process.waitFor();
+            if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
+                log.warning("AsyncProfilerWrapper: profiler process did not exit within "
+                        + KILL_WAIT_SECONDS + "s after destroyForcibly");
+            }
             return false;
         }
         int exitCode = process.exitValue();
@@ -313,7 +318,10 @@ public class AsyncProfilerWrapper {
                 log.warning("AsyncProfilerWrapper: stop timed out after " + STOP_TIMEOUT_SECONDS
                         + "s, destroying process");
                 process.destroyForcibly();
-                process.waitFor();
+                if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
+                    log.warning("AsyncProfilerWrapper: stop process did not exit within "
+                            + KILL_WAIT_SECONDS + "s after destroyForcibly");
+                }
             }
             log.info("AsyncProfilerWrapper: profiling stopped");
         } catch (IOException | InterruptedException e) {
@@ -325,22 +333,49 @@ public class AsyncProfilerWrapper {
 
     /**
      * Kill any lingering asprof child processes of the current JVM that may
-     * be holding the profiler agent from a previous run.  Uses ProcessHandle
-     * (Java 9+) to find child processes whose command line matches the
-     * profiler binary path.
+     * be holding the profiler agent from a previous run, and wait for them
+     * to exit before the new profiler starts.  Uses ProcessHandle (Java 9+)
+     * to find child processes whose executable matches the profiler binary
+     * path.
      */
     private void killLingeringProfilerProcesses(long jvmPid) {
         try {
-            java.lang.ProcessHandle.of(jvmPid).ifPresent(handle ->
+            java.nio.file.Path profilerBin = java.nio.file.Paths.get(profilerPath)
+                    .toAbsolutePath().normalize();
+            java.lang.ProcessHandle.of(jvmPid).ifPresent(handle -> {
+                List<java.lang.ProcessHandle> toKill = new ArrayList<>();
                 handle.descendants().forEach(ph -> {
                     String cmd = ph.info().command().orElse("");
-                    if (cmd.contains("asprof") || cmd.contains("async-profiler")) {
-                        log.info("AsyncProfilerWrapper: killing lingering profiler process PID "
-                                + ph.pid() + " (" + cmd + ")");
-                        ph.destroyForcibly();
+                    if (cmd.isEmpty()) return;
+                    try {
+                        java.nio.file.Path cmdPath = java.nio.file.Paths.get(cmd)
+                                .toAbsolutePath().normalize();
+                        if (cmdPath.equals(profilerBin)) {
+                            log.info("AsyncProfilerWrapper: killing lingering profiler process PID "
+                                    + ph.pid() + " (" + cmd + ")");
+                            toKill.add(ph);
+                        }
+                    } catch (Exception e) {
+                        // Not a valid path — ignore
                     }
-                })
-            );
+                });
+                for (java.lang.ProcessHandle ph : toKill) {
+                    ph.destroyForcibly();
+                    // ProcessHandle has no bounded waitFor — poll isAlive()
+                    long deadline = System.currentTimeMillis() + KILL_WAIT_SECONDS * 1000L;
+                    while (ph.isAlive() && System.currentTimeMillis() < deadline) {
+                        try { Thread.sleep(100); } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                    if (ph.isAlive()) {
+                        log.warning("AsyncProfilerWrapper: lingering profiler process PID "
+                                + ph.pid() + " did not exit within " + KILL_WAIT_SECONDS
+                                + "s after destroyForcibly");
+                    }
+                }
+            });
         } catch (Exception e) {
             log.log(Level.FINE, "AsyncProfilerWrapper: could not check for lingering profiler processes", e);
         }

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -36,6 +36,11 @@ public class AsyncProfilerWrapper {
     // Directory name inside the tarball (matches tarball name minus .tar.gz)
     private static final String PROFILER_DIR_NAME = "async-profiler-3.0-linux-x64";
 
+    /** Timeout for the `asprof stop` command. Prevents a hung stop from blocking the monitoring thread. */
+    private static final int STOP_TIMEOUT_SECONDS = 30;
+    /** Extra buffer (seconds) added to the profiling duration for the run timeout. */
+    private static final int RUN_PROFILER_TIMEOUT_BUFFER_SECONDS = 60;
+
     private final ServerMonitorConfig config;
     private String profilerPath;
     private volatile boolean profilerAvailable = false;
@@ -224,7 +229,17 @@ public class AsyncProfilerWrapper {
             }
         }
 
-        int exitCode = process.waitFor();
+        // Use a timeout (duration + buffer) so a hung profiler process
+        // cannot block the monitoring thread indefinitely.
+        long timeoutSeconds = duration + RUN_PROFILER_TIMEOUT_BUFFER_SECONDS;
+        if (!process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)) {
+            log.warning("AsyncProfilerWrapper: profiler run timed out after " + timeoutSeconds
+                    + "s, destroying process");
+            process.destroyForcibly();
+            process.waitFor();
+            return false;
+        }
+        int exitCode = process.exitValue();
         if (exitCode != 0) {
             log.log(Level.WARNING, "AsyncProfilerWrapper: profiler exited with code " + exitCode + ". stderr: " + stderr);
             return false;
@@ -276,7 +291,16 @@ public class AsyncProfilerWrapper {
             }
             pb.redirectErrorStream(true);
             Process process = pb.start();
-            process.waitFor();
+            // Use a timeout so a hung `asprof stop` (e.g. when the profiler
+            // session already ended) cannot block the monitoring thread
+            // indefinitely.  The hang was observed on strange_gx where a
+            // stuck `asprof stop` killed all subsequent profiling.
+            if (!process.waitFor(STOP_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
+                log.warning("AsyncProfilerWrapper: stop timed out after " + STOP_TIMEOUT_SECONDS
+                        + "s, destroying process");
+                process.destroyForcibly();
+                process.waitFor();
+            }
             log.info("AsyncProfilerWrapper: profiling stopped");
         } catch (IOException | InterruptedException e) {
             log.log(Level.WARNING, "AsyncProfilerWrapper: error stopping profiler", e);

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -195,6 +195,10 @@ public class AsyncProfilerWrapper {
         // still be holding the profiler agent.  This prevents the new
         // `asprof -d` from failing because a prior session hasn't fully
         // released the agent.
+        //
+        // jvmPid is always this JVM's own PID (getJvmPid reads
+        // ManagementFactory.getRuntimeMXBean().getName()), so ProcessHandle
+        // descendants of jvmPid are the asprof child processes we spawned.
         killLingeringProfilerProcesses(jvmPid);
 
         List<String> command = new ArrayList<>();

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -201,7 +201,11 @@ public class AsyncProfilerWrapper {
         // jvmPid is always this JVM's own PID (getJvmPid reads
         // ManagementFactory.getRuntimeMXBean().getName()), so ProcessHandle
         // descendants of jvmPid are the asprof child processes we spawned.
-        killLingeringProfilerProcesses(jvmPid);
+        if (!killLingeringProfilerProcesses(jvmPid)) {
+            log.warning("AsyncProfilerWrapper: lingering profiler process still alive; "
+                    + "not starting a new profiler");
+            return false;
+        }
 
         List<String> command = new ArrayList<>();
         command.add(profilerPath);
@@ -321,9 +325,12 @@ public class AsyncProfilerWrapper {
                 if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
                     log.warning("AsyncProfilerWrapper: stop process did not exit within "
                             + KILL_WAIT_SECONDS + "s after destroyForcibly");
+                } else {
+                    log.info("AsyncProfilerWrapper: profiling stopped");
                 }
+            } else {
+                log.info("AsyncProfilerWrapper: profiling stopped");
             }
-            log.info("AsyncProfilerWrapper: profiling stopped");
         } catch (IOException | InterruptedException e) {
             log.log(Level.WARNING, "AsyncProfilerWrapper: error stopping profiler", e);
         }
@@ -337,20 +344,25 @@ public class AsyncProfilerWrapper {
      * to exit before the new profiler starts.  Uses ProcessHandle (Java 9+)
      * to find child processes whose executable matches the profiler binary
      * path.
+     *
+     * @return true if all matching processes were killed and exited,
+     *         false if any are still alive (caller should not start a
+     *         new profiler in that case)
      */
-    private void killLingeringProfilerProcesses(long jvmPid) {
+    private boolean killLingeringProfilerProcesses(long jvmPid) {
+        boolean allExited = true;
         try {
             java.nio.file.Path profilerBin = java.nio.file.Paths.get(profilerPath)
                     .toAbsolutePath().normalize();
-            java.lang.ProcessHandle.of(jvmPid).ifPresent(handle -> {
-                List<java.lang.ProcessHandle> toKill = new ArrayList<>();
+            List<java.lang.ProcessHandle> toKill = new ArrayList<>();
+            java.lang.ProcessHandle.of(jvmPid).ifPresent(handle ->
                 handle.descendants().forEach(ph -> {
                     String cmd = ph.info().command().orElse("");
                     if (cmd.isEmpty()) return;
                     try {
                         java.nio.file.Path cmdPath = java.nio.file.Paths.get(cmd)
                                 .toAbsolutePath().normalize();
-                        if (cmdPath.equals(profilerBin)) {
+                        if (sameExecutable(cmdPath, profilerBin)) {
                             log.info("AsyncProfilerWrapper: killing lingering profiler process PID "
                                     + ph.pid() + " (" + cmd + ")");
                             toKill.add(ph);
@@ -358,26 +370,44 @@ public class AsyncProfilerWrapper {
                     } catch (Exception e) {
                         // Not a valid path — ignore
                     }
-                });
-                for (java.lang.ProcessHandle ph : toKill) {
-                    ph.destroyForcibly();
-                    // ProcessHandle has no bounded waitFor — poll isAlive()
-                    long deadline = System.currentTimeMillis() + KILL_WAIT_SECONDS * 1000L;
-                    while (ph.isAlive() && System.currentTimeMillis() < deadline) {
-                        try { Thread.sleep(100); } catch (InterruptedException ie) {
-                            Thread.currentThread().interrupt();
-                            break;
-                        }
-                    }
-                    if (ph.isAlive()) {
-                        log.warning("AsyncProfilerWrapper: lingering profiler process PID "
-                                + ph.pid() + " did not exit within " + KILL_WAIT_SECONDS
-                                + "s after destroyForcibly");
+                })
+            );
+            for (java.lang.ProcessHandle ph : toKill) {
+                ph.destroyForcibly();
+                // ProcessHandle has no bounded waitFor — poll isAlive().
+                // Use nanoTime for the deadline (monotonic, unaffected
+                // by NTP/clock changes).
+                long deadline = System.nanoTime()
+                        + java.util.concurrent.TimeUnit.SECONDS.toNanos(KILL_WAIT_SECONDS);
+                while (ph.isAlive() && System.nanoTime() < deadline) {
+                    try { Thread.sleep(100); } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return false;
                     }
                 }
-            });
+                if (ph.isAlive()) {
+                    allExited = false;
+                    log.warning("AsyncProfilerWrapper: lingering profiler process PID "
+                            + ph.pid() + " did not exit within " + KILL_WAIT_SECONDS
+                            + "s after destroyForcibly");
+                }
+            }
         } catch (Exception e) {
             log.log(Level.FINE, "AsyncProfilerWrapper: could not check for lingering profiler processes", e);
+        }
+        return allExited;
+    }
+
+    /**
+     * Compare two paths for identity, resolving symlinks where possible.
+     * Falls back to normalized absolute path comparison if toRealPath
+     * fails (e.g. file doesn't exist).
+     */
+    private static boolean sameExecutable(java.nio.file.Path a, java.nio.file.Path b) {
+        try {
+            return a.toRealPath().equals(b.toRealPath());
+        } catch (java.io.IOException e) {
+            return a.toAbsolutePath().normalize().equals(b.toAbsolutePath().normalize());
         }
     }
 

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -191,6 +191,12 @@ public class AsyncProfilerWrapper {
      */
     private boolean runProfiler(long jvmPid, String threadIdStr, int duration, String outputPath, String outputFormat)
             throws IOException, InterruptedException {
+        // Kill any lingering asprof processes from a previous run that may
+        // still be holding the profiler agent.  This prevents the new
+        // `asprof -d` from failing because a prior session hasn't fully
+        // released the agent.
+        killLingeringProfilerProcesses(jvmPid);
+
         List<String> command = new ArrayList<>();
         command.add(profilerPath);
         command.add("-d");
@@ -311,6 +317,29 @@ public class AsyncProfilerWrapper {
         }
 
         activeProfileOutputPath = null;
+    }
+
+    /**
+     * Kill any lingering asprof child processes of the current JVM that may
+     * be holding the profiler agent from a previous run.  Uses ProcessHandle
+     * (Java 9+) to find child processes whose command line matches the
+     * profiler binary path.
+     */
+    private void killLingeringProfilerProcesses(long jvmPid) {
+        try {
+            java.lang.ProcessHandle.of(jvmPid).ifPresent(handle ->
+                handle.descendants().forEach(ph -> {
+                    String cmd = ph.info().command().orElse("");
+                    if (cmd.contains("asprof") || cmd.contains("async-profiler")) {
+                        log.info("AsyncProfilerWrapper: killing lingering profiler process PID "
+                                + ph.pid() + " (" + cmd + ")");
+                        ph.destroyForcibly();
+                    }
+                })
+            );
+        } catch (Exception e) {
+            log.log(Level.FINE, "AsyncProfilerWrapper: could not check for lingering profiler processes", e);
+        }
     }
 
     /**

--- a/src/com/developmentontheedge/application/ApplicationUtils.java
+++ b/src/com/developmentontheedge/application/ApplicationUtils.java
@@ -444,7 +444,7 @@ public class ApplicationUtils
         }
         catch( IOException e )
         {
-            // walkFileTree only throws on the root; fall back to deleteOnExit
+            // Fall back to deleteOnExit if the traversal itself failed
             dir.deleteOnExit();
         }
     }

--- a/src/com/developmentontheedge/application/ApplicationUtils.java
+++ b/src/com/developmentontheedge/application/ApplicationUtils.java
@@ -25,7 +25,11 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -400,23 +404,47 @@ public class ApplicationUtils
     {
         if (dir == null || !dir.isDirectory())
             return;
-        File[] files = dir.listFiles();
-        if (files != null)
+        // Use walkFileTree instead of recursive listFiles+isDirectory: it batches
+        // directory reads via DirectoryStream and avoids a redundant stat per child
+        // (isDirectory then delete), which dominates CPU on large temp trees.
+        try
         {
-            for( File file : files )
+            Files.walkFileTree(dir.toPath(), new FileVisitor<Path>()
             {
-                if(file.isDirectory())
+                @Override
+                public FileVisitResult preVisitDirectory(Path file, BasicFileAttributes attrs)
                 {
-                    removeDir(file);
+                    return FileVisitResult.CONTINUE;
                 }
-                if(!file.delete())
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                 {
-                    file.deleteOnExit();
+                    if(!file.toFile().delete())
+                    {
+                        file.toFile().deleteOnExit();
+                    }
+                    return FileVisitResult.CONTINUE;
                 }
-            }
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc)
+                {
+                    file.toFile().deleteOnExit();
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                {
+                    if(!dir.toFile().delete())
+                    {
+                        dir.toFile().deleteOnExit();
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
         }
-        if(!dir.delete())
+        catch( IOException e )
         {
+            // walkFileTree only throws on the root; fall back to deleteOnExit
             dir.deleteOnExit();
         }
     }

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -480,19 +480,7 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
         List<String> sortedNameList = getSortedNameList(field, direction);
         List<String> subList = sortedNameList.subList( from, to );
         if( subList.isEmpty() )
-            return new Iterator<T>()
-            {
-                @Override
-                public boolean hasNext()
-                {
-                    return false;
-                }
-                @Override
-                public T next()
-                {
-                    throw new java.util.NoSuchElementException();
-                }
-            };
+            return java.util.Collections.<T>emptyIterator();
 
         // Batch-fetch all rows in one query instead of N+1 individual lookups.
         // The old path (createDataCollectionIterator) called doGet(name) per row,
@@ -505,11 +493,25 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
             for( String name : subList )
                 inClause.add( SqlUtil.quoteString( name ) );
 
+            String idFilter = transformer.getIdField() + " IN (" + inClause + ")";
+
+            // Insert the IN filter before any trailing ORDER BY / GROUP BY /
+            // LIMIT clause.  Naively appending to the end produces invalid
+            // SQL when getSelectQuery() includes such a clause (e.g.
+            // DataElementsSqlTransformer returns "... ORDER BY name").
             String batchQuery;
-            if( selectQuery.contains(" WHERE ") )
-                batchQuery = selectQuery + " AND " + transformer.getIdField() + " IN (" + inClause + ")";
-            else
-                batchQuery = selectQuery + " WHERE " + transformer.getIdField() + " IN (" + inClause + ")";
+            int orderIdx = findTrailingClauseIndex( selectQuery, "ORDER BY" );
+            int groupIdx = findTrailingClauseIndex( selectQuery, "GROUP BY" );
+            int limitIdx = findTrailingClauseIndex( selectQuery, "LIMIT" );
+            int insertIdx = Math.min(
+                    Math.min( orderIdx == -1 ? selectQuery.length() : orderIdx,
+                              groupIdx == -1 ? selectQuery.length() : groupIdx ),
+                    limitIdx == -1 ? selectQuery.length() : limitIdx );
+
+            String before = selectQuery.substring( 0, insertIdx );
+            String after  = selectQuery.substring( insertIdx );
+            String connector = before.contains( "WHERE" ) ? "AND " : "WHERE ";
+            batchQuery = before + " " + connector + idFilter + ( after.isEmpty() ? "" : " " + after );
 
             Map<String, T> byName = new HashMap<>();
             try( Statement statement = getConnection().createStatement(); ResultSet rs = statement.executeQuery( batchQuery ) )
@@ -519,6 +521,13 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
                     T element = transformer.create( rs, getConnection() );
                     byName.put( element.getName(), element );
                 }
+            }
+
+            if( byName.size() < subList.size() )
+            {
+                log.log( Level.FINE,
+                        "getSortedIterator: batch query returned {0}/{1} rows — some will fall back to per-row doGet",
+                        new Object[]{ byName.size(), subList.size() } );
             }
 
             final Map<String, T> result = byName;
@@ -558,6 +567,34 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
             log.log( Level.SEVERE, "Batch query in getSortedIterator failed, falling back to per-row", e );
             return AbstractDataCollection.createDataCollectionIterator( this, subList.iterator() );
         }
+    }
+
+    /**
+     * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
+     * a query string, ignoring occurrences inside string literals.
+     * Returns -1 if the clause is not found.
+     */
+    private static int findTrailingClauseIndex( String sql, String clause )
+    {
+        // Case-insensitive search, but skip occurrences inside single-quoted
+        // string literals to avoid false positives.
+        String upper = sql.toUpperCase();
+        String clauseUpper = clause.toUpperCase();
+        boolean inQuote = false;
+        for( int i = 0; i < sql.length(); i++ )
+        {
+            char c = sql.charAt( i );
+            if( c == '\'' )
+                inQuote = !inQuote;
+            if( !inQuote && upper.startsWith( clauseUpper, i ) )
+            {
+                // Ensure the clause is a whole word (followed by space or end)
+                int end = i + clauseUpper.length();
+                if( end >= upper.length() || upper.charAt( end ) == ' ' )
+                    return i;
+            }
+        }
+        return -1;
     }
 
     @Override

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -546,8 +546,10 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
         }
         catch( Exception e )
         {
-            // Fall back to the per-row iterator if the batch query fails
-            log.log( Level.SEVERE, "Batch query in getSortedIterator failed, falling back to per-row", e );
+            // Fall back to the per-row iterator if the batch query fails.
+            // WARNING (not SEVERE): this is expected compatibility behavior
+            // for transformers whose SQL doesn't match the supported shapes.
+            log.log( Level.WARNING, "Batch query in getSortedIterator failed, falling back to per-row", e );
             return AbstractDataCollection.createDataCollectionIterator( this, subList.iterator() );
         }
     }

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -5,10 +5,13 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.StringJoiner;
 
 import javax.annotation.Nonnull;
 
@@ -475,7 +478,86 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
     public Iterator<T> getSortedIterator(String field, boolean direction, int from, int to)
     {
         List<String> sortedNameList = getSortedNameList(field, direction);
-        return AbstractDataCollection.createDataCollectionIterator( this, sortedNameList.subList( from, to ).iterator() );
+        List<String> subList = sortedNameList.subList( from, to );
+        if( subList.isEmpty() )
+            return new Iterator<T>()
+            {
+                @Override
+                public boolean hasNext()
+                {
+                    return false;
+                }
+                @Override
+                public T next()
+                {
+                    throw new java.util.NoSuchElementException();
+                }
+            };
+
+        // Batch-fetch all rows in one query instead of N+1 individual lookups.
+        // The old path (createDataCollectionIterator) called doGet(name) per row,
+        // issuing one SELECT per element. Profiling on strange.genexplain.com
+        // showed this was 43% of WebTablesProvider CPU time.
+        try
+        {
+            String selectQuery = transformer.getSelectQuery();
+            StringJoiner inClause = new StringJoiner( "," );
+            for( String name : subList )
+                inClause.add( SqlUtil.quoteString( name ) );
+
+            String batchQuery;
+            if( selectQuery.contains(" WHERE ") )
+                batchQuery = selectQuery + " AND " + transformer.getIdField() + " IN (" + inClause + ")";
+            else
+                batchQuery = selectQuery + " WHERE " + transformer.getIdField() + " IN (" + inClause + ")";
+
+            Map<String, T> byName = new HashMap<>();
+            try( Statement statement = getConnection().createStatement(); ResultSet rs = statement.executeQuery( batchQuery ) )
+            {
+                while( rs.next() )
+                {
+                    T element = transformer.create( rs, getConnection() );
+                    byName.put( element.getName(), element );
+                }
+            }
+
+            final Map<String, T> result = byName;
+            Iterator<String> nameIter = subList.iterator();
+            return new Iterator<T>()
+            {
+                @Override
+                public boolean hasNext()
+                {
+                    return nameIter.hasNext();
+                }
+                @Override
+                public T next()
+                {
+                    String name = nameIter.next();
+                    T element = result.get( name );
+                    if( element == null )
+                    {
+                        // Fallback for rows the batch query didn't return
+                        // (e.g. filtered out by a transformer-specific condition)
+                        try
+                        {
+                            element = doGet( name );
+                        }
+                        catch( Exception e )
+                        {
+                            throw new RuntimeException( e );
+                        }
+                    }
+                    return element;
+                }
+            };
+        }
+        catch( Exception e )
+        {
+            // Fall back to the per-row iterator if the batch query fails
+            log.log( Level.SEVERE, "Batch query in getSortedIterator failed, falling back to per-row", e );
+            return AbstractDataCollection.createDataCollectionIterator( this, subList.iterator() );
+        }
     }
 
     @Override

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -560,9 +560,7 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
      *   <li>whole-word boundaries on both sides (the preceding and
      *       following characters, if any, must not be letters or digits),</li>
      *   <li>the match must not be inside a single-quoted string literal
-     *       or a backtick-quoted identifier,</li>
-     *   <li>the match must be followed by a non-identifier character or
-     *       end-of-string (so "WHEREX" doesn't match "WHERE").</li>
+     *       or a backtick-quoted identifier.</li>
      * </ul>
      * Mutual guards (!inBacktick / !inSingleQuote) prevent a backtick
      * inside a single-quoted literal (e.g. {@code 'can`stop'}) from
@@ -575,8 +573,17 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
      * on finding the <em>outermost</em> occurrence should not use this
      * method on queries with nested subqueries.  None of the current
      * SqlTransformer.getSelectQuery() implementations have such subqueries.
+     *
+     * @param sql the SQL string to search
+     * @param word the keyword to look for
+     * @param requireWhitespaceRightBoundary if true, the character after
+     *        the match must be whitespace or end-of-string (not merely a
+     *        non-identifier character).  Use this for multi-word clauses
+     *        like "ORDER BY" where the right boundary must be actual
+     *        whitespace for the clause to be a complete token.
+     * @return the index of the first match, or -1 if not found
      */
-    private static int indexOfWholeWord( String sql, String word )
+    private static int indexOfWholeWord( String sql, String word, boolean requireWhitespaceRightBoundary )
     {
         String upper = sql.toUpperCase();
         String wordUpper = word.toUpperCase();
@@ -596,11 +603,23 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
                 if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
                     continue;
                 int end = i + wordUpper.length();
-                if( end >= upper.length() || !Character.isLetterOrDigit( upper.charAt( end ) ) )
+                if( end >= upper.length()
+                        || ( requireWhitespaceRightBoundary
+                             ? Character.isWhitespace( upper.charAt( end ) )
+                             : !Character.isLetterOrDigit( upper.charAt( end ) ) ) )
                     return i;
             }
         }
         return -1;
+    }
+
+    /**
+     * Case-insensitive whole-word search with a non-identifier right
+     * boundary.  See {@link #indexOfWholeWord(String, String, boolean)}.
+     */
+    private static int indexOfWholeWord( String sql, String word )
+    {
+        return indexOfWholeWord( sql, word, false );
     }
 
     /**
@@ -616,43 +635,18 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
     /**
      * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
      * a query string, ignoring occurrences inside string literals and
-     * backtick-quoted identifiers.  Delegates to {@link #indexOfWholeWord}
-     * for the tokenization scan; the only difference is that the right
-     * boundary must be whitespace (not just a non-identifier character)
-     * to handle multi-clause keywords like "ORDER BY" where the space
-     * between the two words is part of the token.
+     * backtick-quoted identifiers.  Delegates to
+     * {@link #indexOfWholeWord(String, String, boolean)} with
+     * {@code requireWhitespaceRightBoundary=true}; the only difference from
+     * the default scan is that the right boundary must be whitespace (not
+     * just a non-identifier character) to handle multi-word clauses like
+     * "ORDER BY" where a non-whitespace character after the clause (e.g.
+     * "ORDER BYX") would not constitute a complete clause token.
      * Returns -1 if the clause is not found.
      */
     private static int findTrailingClauseIndex( String sql, String clause )
     {
-        // indexOfWholeWord treats the right boundary as "not a letter/digit",
-        // which is too permissive for multi-word clauses: "ORDER BYX" would
-        // match "ORDER BY" (space after BY is a non-identifier char).  For
-        // trailing-clause detection we need the right boundary to be actual
-        // whitespace.  Re-scan with the stricter check.
-        String upper = sql.toUpperCase();
-        String clauseUpper = clause.toUpperCase();
-        boolean inSingleQuote = false;
-        boolean inBacktick = false;
-        for( int i = 0; i < upper.length(); i++ )
-        {
-            char c = sql.charAt( i );
-            if( c == '\'' && !inBacktick )
-                inSingleQuote = !inSingleQuote;
-            else if( c == '`' && !inSingleQuote )
-                inBacktick = !inBacktick;
-            if( inSingleQuote || inBacktick )
-                continue;
-            if( upper.startsWith( clauseUpper, i ) )
-            {
-                if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
-                    continue;
-                int end = i + clauseUpper.length();
-                if( end >= upper.length() || Character.isWhitespace( upper.charAt( end ) ) )
-                    return i;
-            }
-        }
-        return -1;
+        return indexOfWholeWord( sql, clause, true );
     }
 
     /**

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -510,7 +510,9 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
 
             String before = selectQuery.substring( 0, insertIdx );
             String after  = selectQuery.substring( insertIdx );
-            String connector = before.contains( "WHERE" ) ? "AND " : "WHERE ";
+            // Case-insensitive word-boundary check: matches "WHERE" as a whole
+            // word, not as a substring of an identifier or inside a literal.
+            String connector = hasWholeWord( before, "WHERE" ) ? "AND " : "WHERE ";
             batchQuery = before + " " + connector + idFilter + ( after.isEmpty() ? "" : " " + after );
 
             Map<String, T> byName = new HashMap<>();
@@ -571,30 +573,73 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
 
     /**
      * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
-     * a query string, ignoring occurrences inside string literals.
+     * a query string, ignoring occurrences inside string literals and
+     * backtick-quoted identifiers.  Uses whole-word boundaries on both sides
+     * and accepts any whitespace (not just space) after the clause keyword,
+     * so multi-line formatted queries are handled correctly.
      * Returns -1 if the clause is not found.
      */
     private static int findTrailingClauseIndex( String sql, String clause )
     {
-        // Case-insensitive search, but skip occurrences inside single-quoted
-        // string literals to avoid false positives.
         String upper = sql.toUpperCase();
         String clauseUpper = clause.toUpperCase();
-        boolean inQuote = false;
+        boolean inSingleQuote = false;
+        boolean inBacktick = false;
         for( int i = 0; i < sql.length(); i++ )
         {
             char c = sql.charAt( i );
-            if( c == '\'' )
-                inQuote = !inQuote;
-            if( !inQuote && upper.startsWith( clauseUpper, i ) )
+            if( c == '\'' && !inBacktick )
+                inSingleQuote = !inSingleQuote;
+            else if( c == '`' && !inSingleQuote )
+                inBacktick = !inBacktick;
+            if( (inSingleQuote || inBacktick) )
+                continue;
+            if( upper.startsWith( clauseUpper, i ) )
             {
-                // Ensure the clause is a whole word (followed by space or end)
+                // Left boundary: must be start of string or preceded by a
+                // non-identifier character (prevents matching "xORDER BY").
+                if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
+                    continue;
+                // Right boundary: must be end of string or followed by any
+                // whitespace (not just space, to handle newlines/tabs).
                 int end = i + clauseUpper.length();
-                if( end >= upper.length() || upper.charAt( end ) == ' ' )
+                if( end >= upper.length() || Character.isWhitespace( upper.charAt( end ) ) )
                     return i;
             }
         }
         return -1;
+    }
+
+    /**
+     * Case-insensitive whole-word check: returns true if the given word
+     * appears as a standalone token in the string (not as a substring of an
+     * identifier, and not inside single-quoted or backtick-quoted literals).
+     */
+    private static boolean hasWholeWord( String sql, String word )
+    {
+        String upper = sql.toUpperCase();
+        String wordUpper = word.toUpperCase();
+        boolean inSingleQuote = false;
+        boolean inBacktick = false;
+        for( int i = 0; i < upper.length(); i++ )
+        {
+            char c = sql.charAt( i );
+            if( c == '\'' && !inBacktick )
+                inSingleQuote = !inSingleQuote;
+            else if( c == '`' && !inSingleQuote )
+                inBacktick = !inBacktick;
+            if( inSingleQuote || inBacktick )
+                continue;
+            if( upper.startsWith( wordUpper, i ) )
+            {
+                if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
+                    continue;
+                int end = i + wordUpper.length();
+                if( end >= upper.length() || !Character.isLetterOrDigit( upper.charAt( end ) ) )
+                    return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -553,131 +553,30 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
     }
 
     /**
-     * Build a batch-fetch query by inserting an id filter into a SELECT
-     * query, before any trailing ORDER BY / GROUP BY / LIMIT clause.
-     *
-     * If the query already has a WHERE clause, the pre-existing condition
-     * is wrapped in parentheses before the AND is appended.  This is
-     * necessary because AND binds tighter than OR in SQL: without
-     * parenthesization, "... WHERE a=1 OR b=2 AND id IN (...)" would parse
-     * as "a=1 OR (b=2 AND id IN (...))", silently returning rows matching
-     * a=1 that are NOT in the requested batch.
+     * Case-insensitive whole-word search: returns the index of the first
+     * occurrence of {@code word} as a standalone token in {@code sql},
+     * or -1 if not found.  A match requires:
+     * <ul>
+     *   <li>whole-word boundaries on both sides (the preceding and
+     *       following characters, if any, must not be letters or digits),</li>
+     *   <li>the match must not be inside a single-quoted string literal
+     *       or a backtick-quoted identifier,</li>
+     *   <li>the match must be followed by a non-identifier character or
+     *       end-of-string (so "WHEREX" doesn't match "WHERE").</li>
+     * </ul>
+     * Mutual guards (!inBacktick / !inSingleQuote) prevent a backtick
+     * inside a single-quoted literal (e.g. {@code 'can`stop'}) from
+     * toggling backtick-state, and vice versa.  Intentional — do not
+     * simplify.
      *
      * Known limitation: no parenthesis-depth tracking, so a subquery
-     * containing its own ORDER BY / LIMIT would cause the insertion point
-     * to land inside the subquery rather than at the outer clause boundary.
-     * None of the current SqlTransformer implementations have such
-     * subqueries in getSelectQuery().
+     * containing the target word earlier in the string than the outer
+     * occurrence will match first (leftmost wins).  Callers that depend
+     * on finding the <em>outermost</em> occurrence should not use this
+     * method on queries with nested subqueries.  None of the current
+     * SqlTransformer.getSelectQuery() implementations have such subqueries.
      */
-    static String buildBatchQuery( String selectQuery, String idFilter )
-    {
-        int orderIdx = findTrailingClauseIndex( selectQuery, "ORDER BY" );
-        int groupIdx = findTrailingClauseIndex( selectQuery, "GROUP BY" );
-        int limitIdx = findTrailingClauseIndex( selectQuery, "LIMIT" );
-        int insertIdx = Math.min(
-                Math.min( orderIdx == -1 ? selectQuery.length() : orderIdx,
-                          groupIdx == -1 ? selectQuery.length() : groupIdx ),
-                limitIdx == -1 ? selectQuery.length() : limitIdx );
-
-        String before = selectQuery.substring( 0, insertIdx ).trim();
-        String after  = selectQuery.substring( insertIdx );
-        String afterPart = after.isEmpty() ? "" : " " + after.trim();
-
-        if( !hasWholeWord( before, "WHERE" ) )
-            return before + " WHERE " + idFilter + afterPart;
-
-        // Has a WHERE clause: find its position and wrap the existing
-        // condition in parentheses so the appended AND doesn't change
-        // the semantics of any top-level OR in the pre-existing condition.
-        // The original case of the WHERE keyword is preserved.
-        String beforeUpper = before.toUpperCase();
-        int wherePos = -1;
-        {
-            // Reuse the same literal-skipping scan as hasWholeWord to find
-            // the first real WHERE keyword position.
-            boolean inSingleQuote = false;
-            boolean inBacktick = false;
-            for( int i = 0; i < before.length(); i++ )
-            {
-                char c = before.charAt( i );
-                if( c == '\'' && !inBacktick )
-                    inSingleQuote = !inSingleQuote;
-                else if( c == '`' && !inSingleQuote )
-                    inBacktick = !inBacktick;
-                if( inSingleQuote || inBacktick )
-                    continue;
-                if( beforeUpper.startsWith( "WHERE", i ) )
-                {
-                    if( i > 0 && Character.isLetterOrDigit( before.charAt( i - 1 ) ) )
-                        continue;
-                    int end = i + 5;
-                    if( end >= before.length() || !Character.isLetterOrDigit( before.charAt( end ) ) )
-                    {
-                        wherePos = i;
-                        break;
-                    }
-                }
-            }
-        }
-        if( wherePos == -1 )
-            // hasWholeWord said yes but position search failed — shouldn't
-            // happen; fall through to safe no-parenthesization path.
-            return before + " AND " + idFilter + afterPart;
-
-        String preWhere  = before.substring( 0, wherePos );
-        String whereKw   = before.substring( wherePos, wherePos + "WHERE".length() );
-        String condition = before.substring( wherePos + "WHERE".length() ).trim();
-        return preWhere + whereKw + " (" + condition + ") AND " + idFilter + afterPart;
-    }
-
-    /**
-     * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
-     * a query string, ignoring occurrences inside string literals and
-     * backtick-quoted identifiers.  Uses whole-word boundaries on both sides
-     * and accepts any whitespace (not just space) after the clause keyword,
-     * so multi-line formatted queries are handled correctly.
-     * Returns -1 if the clause is not found.
-     */
-    private static int findTrailingClauseIndex( String sql, String clause )
-    {
-        String upper = sql.toUpperCase();
-        String clauseUpper = clause.toUpperCase();
-        boolean inSingleQuote = false;
-        boolean inBacktick = false;
-        for( int i = 0; i < sql.length(); i++ )
-        {
-            char c = sql.charAt( i );
-            // Mutual guards (!inBacktick / !inSingleQuote) prevent a backtick
-            // inside a single-quoted literal (e.g. 'can`stop') from toggling
-            // backtick-state, and vice versa.  Intentional — do not simplify.
-            if( c == '\'' && !inBacktick )
-                inSingleQuote = !inSingleQuote;
-            else if( c == '`' && !inSingleQuote )
-                inBacktick = !inBacktick;
-            if( (inSingleQuote || inBacktick) )
-                continue;
-            if( upper.startsWith( clauseUpper, i ) )
-            {
-                // Left boundary: must be start of string or preceded by a
-                // non-identifier character (prevents matching "xORDER BY").
-                if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
-                    continue;
-                // Right boundary: must be end of string or followed by any
-                // whitespace (not just space, to handle newlines/tabs).
-                int end = i + clauseUpper.length();
-                if( end >= upper.length() || Character.isWhitespace( upper.charAt( end ) ) )
-                    return i;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Case-insensitive whole-word check: returns true if the given word
-     * appears as a standalone token in the string (not as a substring of an
-     * identifier, and not inside single-quoted or backtick-quoted literals).
-     */
-    private static boolean hasWholeWord( String sql, String word )
+    private static int indexOfWholeWord( String sql, String word )
     {
         String upper = sql.toUpperCase();
         String wordUpper = word.toUpperCase();
@@ -698,10 +597,107 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
                     continue;
                 int end = i + wordUpper.length();
                 if( end >= upper.length() || !Character.isLetterOrDigit( upper.charAt( end ) ) )
-                    return true;
+                    return i;
             }
         }
-        return false;
+        return -1;
+    }
+
+    /**
+     * Case-insensitive whole-word check: returns true if the given word
+     * appears as a standalone token in the string (not as a substring of an
+     * identifier, and not inside single-quoted or backtick-quoted literals).
+     */
+    private static boolean hasWholeWord( String sql, String word )
+    {
+        return indexOfWholeWord( sql, word ) >= 0;
+    }
+
+    /**
+     * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
+     * a query string, ignoring occurrences inside string literals and
+     * backtick-quoted identifiers.  Delegates to {@link #indexOfWholeWord}
+     * for the tokenization scan; the only difference is that the right
+     * boundary must be whitespace (not just a non-identifier character)
+     * to handle multi-clause keywords like "ORDER BY" where the space
+     * between the two words is part of the token.
+     * Returns -1 if the clause is not found.
+     */
+    private static int findTrailingClauseIndex( String sql, String clause )
+    {
+        // indexOfWholeWord treats the right boundary as "not a letter/digit",
+        // which is too permissive for multi-word clauses: "ORDER BYX" would
+        // match "ORDER BY" (space after BY is a non-identifier char).  For
+        // trailing-clause detection we need the right boundary to be actual
+        // whitespace.  Re-scan with the stricter check.
+        String upper = sql.toUpperCase();
+        String clauseUpper = clause.toUpperCase();
+        boolean inSingleQuote = false;
+        boolean inBacktick = false;
+        for( int i = 0; i < upper.length(); i++ )
+        {
+            char c = sql.charAt( i );
+            if( c == '\'' && !inBacktick )
+                inSingleQuote = !inSingleQuote;
+            else if( c == '`' && !inSingleQuote )
+                inBacktick = !inBacktick;
+            if( inSingleQuote || inBacktick )
+                continue;
+            if( upper.startsWith( clauseUpper, i ) )
+            {
+                if( i > 0 && Character.isLetterOrDigit( sql.charAt( i - 1 ) ) )
+                    continue;
+                int end = i + clauseUpper.length();
+                if( end >= upper.length() || Character.isWhitespace( upper.charAt( end ) ) )
+                    return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Build a batch-fetch query by inserting an id filter into a SELECT
+     * query, before any trailing ORDER BY / GROUP BY / LIMIT clause.
+     *
+     * If the query already has a WHERE clause, the pre-existing condition
+     * is wrapped in parentheses before the AND is appended.  This is
+     * necessary because AND binds tighter than OR in SQL: without
+     * parenthesization, "... WHERE a=1 OR b=2 AND id IN (...)" would parse
+     * as "a=1 OR (b=2 AND id IN (...))", silently returning rows matching
+     * a=1 that are NOT in the requested batch.
+     *
+     * Known limitation: no parenthesis-depth tracking, so a subquery
+     * containing its own ORDER BY / LIMIT / WHERE earlier in the string
+     * than the outer occurrence will be matched first, causing the
+     * insertion point or parenthesization to target the subquery rather
+     * than the outer clause.  None of the current SqlTransformer
+     * implementations have such subqueries in getSelectQuery().
+     */
+    private static String buildBatchQuery( String selectQuery, String idFilter )
+    {
+        int orderIdx = findTrailingClauseIndex( selectQuery, "ORDER BY" );
+        int groupIdx = findTrailingClauseIndex( selectQuery, "GROUP BY" );
+        int limitIdx = findTrailingClauseIndex( selectQuery, "LIMIT" );
+        int insertIdx = Math.min(
+                Math.min( orderIdx == -1 ? selectQuery.length() : orderIdx,
+                          groupIdx == -1 ? selectQuery.length() : groupIdx ),
+                limitIdx == -1 ? selectQuery.length() : limitIdx );
+
+        String before = selectQuery.substring( 0, insertIdx ).trim();
+        String after  = selectQuery.substring( insertIdx );
+        String afterPart = after.isEmpty() ? "" : " " + after.trim();
+
+        int wherePos = indexOfWholeWord( before, "WHERE" );
+        if( wherePos == -1 )
+            return before + " WHERE " + idFilter + afterPart;
+
+        // Wrap the existing condition in parentheses so the appended AND
+        // doesn't change the semantics of any top-level OR.  The original
+        // case of the WHERE keyword is preserved.
+        String preWhere  = before.substring( 0, wherePos );
+        String whereKw   = before.substring( wherePos, wherePos + "WHERE".length() );
+        String condition = before.substring( wherePos + "WHERE".length() ).trim();
+        return preWhere + whereKw + " (" + condition + ") AND " + idFilter + afterPart;
     }
 
     @Override

--- a/src/ru/biosoft/access/SqlDataCollection.java
+++ b/src/ru/biosoft/access/SqlDataCollection.java
@@ -494,26 +494,7 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
                 inClause.add( SqlUtil.quoteString( name ) );
 
             String idFilter = transformer.getIdField() + " IN (" + inClause + ")";
-
-            // Insert the IN filter before any trailing ORDER BY / GROUP BY /
-            // LIMIT clause.  Naively appending to the end produces invalid
-            // SQL when getSelectQuery() includes such a clause (e.g.
-            // DataElementsSqlTransformer returns "... ORDER BY name").
-            String batchQuery;
-            int orderIdx = findTrailingClauseIndex( selectQuery, "ORDER BY" );
-            int groupIdx = findTrailingClauseIndex( selectQuery, "GROUP BY" );
-            int limitIdx = findTrailingClauseIndex( selectQuery, "LIMIT" );
-            int insertIdx = Math.min(
-                    Math.min( orderIdx == -1 ? selectQuery.length() : orderIdx,
-                              groupIdx == -1 ? selectQuery.length() : groupIdx ),
-                    limitIdx == -1 ? selectQuery.length() : limitIdx );
-
-            String before = selectQuery.substring( 0, insertIdx );
-            String after  = selectQuery.substring( insertIdx );
-            // Case-insensitive word-boundary check: matches "WHERE" as a whole
-            // word, not as a substring of an identifier or inside a literal.
-            String connector = hasWholeWord( before, "WHERE" ) ? "AND " : "WHERE ";
-            batchQuery = before + " " + connector + idFilter + ( after.isEmpty() ? "" : " " + after );
+            String batchQuery = buildBatchQuery( selectQuery, idFilter );
 
             Map<String, T> byName = new HashMap<>();
             try( Statement statement = getConnection().createStatement(); ResultSet rs = statement.executeQuery( batchQuery ) )
@@ -572,6 +553,84 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
     }
 
     /**
+     * Build a batch-fetch query by inserting an id filter into a SELECT
+     * query, before any trailing ORDER BY / GROUP BY / LIMIT clause.
+     *
+     * If the query already has a WHERE clause, the pre-existing condition
+     * is wrapped in parentheses before the AND is appended.  This is
+     * necessary because AND binds tighter than OR in SQL: without
+     * parenthesization, "... WHERE a=1 OR b=2 AND id IN (...)" would parse
+     * as "a=1 OR (b=2 AND id IN (...))", silently returning rows matching
+     * a=1 that are NOT in the requested batch.
+     *
+     * Known limitation: no parenthesis-depth tracking, so a subquery
+     * containing its own ORDER BY / LIMIT would cause the insertion point
+     * to land inside the subquery rather than at the outer clause boundary.
+     * None of the current SqlTransformer implementations have such
+     * subqueries in getSelectQuery().
+     */
+    static String buildBatchQuery( String selectQuery, String idFilter )
+    {
+        int orderIdx = findTrailingClauseIndex( selectQuery, "ORDER BY" );
+        int groupIdx = findTrailingClauseIndex( selectQuery, "GROUP BY" );
+        int limitIdx = findTrailingClauseIndex( selectQuery, "LIMIT" );
+        int insertIdx = Math.min(
+                Math.min( orderIdx == -1 ? selectQuery.length() : orderIdx,
+                          groupIdx == -1 ? selectQuery.length() : groupIdx ),
+                limitIdx == -1 ? selectQuery.length() : limitIdx );
+
+        String before = selectQuery.substring( 0, insertIdx ).trim();
+        String after  = selectQuery.substring( insertIdx );
+        String afterPart = after.isEmpty() ? "" : " " + after.trim();
+
+        if( !hasWholeWord( before, "WHERE" ) )
+            return before + " WHERE " + idFilter + afterPart;
+
+        // Has a WHERE clause: find its position and wrap the existing
+        // condition in parentheses so the appended AND doesn't change
+        // the semantics of any top-level OR in the pre-existing condition.
+        // The original case of the WHERE keyword is preserved.
+        String beforeUpper = before.toUpperCase();
+        int wherePos = -1;
+        {
+            // Reuse the same literal-skipping scan as hasWholeWord to find
+            // the first real WHERE keyword position.
+            boolean inSingleQuote = false;
+            boolean inBacktick = false;
+            for( int i = 0; i < before.length(); i++ )
+            {
+                char c = before.charAt( i );
+                if( c == '\'' && !inBacktick )
+                    inSingleQuote = !inSingleQuote;
+                else if( c == '`' && !inSingleQuote )
+                    inBacktick = !inBacktick;
+                if( inSingleQuote || inBacktick )
+                    continue;
+                if( beforeUpper.startsWith( "WHERE", i ) )
+                {
+                    if( i > 0 && Character.isLetterOrDigit( before.charAt( i - 1 ) ) )
+                        continue;
+                    int end = i + 5;
+                    if( end >= before.length() || !Character.isLetterOrDigit( before.charAt( end ) ) )
+                    {
+                        wherePos = i;
+                        break;
+                    }
+                }
+            }
+        }
+        if( wherePos == -1 )
+            // hasWholeWord said yes but position search failed — shouldn't
+            // happen; fall through to safe no-parenthesization path.
+            return before + " AND " + idFilter + afterPart;
+
+        String preWhere  = before.substring( 0, wherePos );
+        String whereKw   = before.substring( wherePos, wherePos + "WHERE".length() );
+        String condition = before.substring( wherePos + "WHERE".length() ).trim();
+        return preWhere + whereKw + " (" + condition + ") AND " + idFilter + afterPart;
+    }
+
+    /**
      * Find the index of a trailing SQL clause (ORDER BY, GROUP BY, LIMIT) in
      * a query string, ignoring occurrences inside string literals and
      * backtick-quoted identifiers.  Uses whole-word boundaries on both sides
@@ -588,6 +647,9 @@ public class SqlDataCollection<T extends DataElement> extends AbstractDataCollec
         for( int i = 0; i < sql.length(); i++ )
         {
             char c = sql.charAt( i );
+            // Mutual guards (!inBacktick / !inSingleQuote) prevent a backtick
+            // inside a single-quoted literal (e.g. 'can`stop') from toggling
+            // backtick-state, and vice versa.  Intentional — do not simplify.
             if( c == '\'' && !inBacktick )
                 inSingleQuote = !inSingleQuote;
             else if( c == '`' && !inSingleQuote )

--- a/src/ru/biosoft/access/SqlTransformer.java
+++ b/src/ru/biosoft/access/SqlTransformer.java
@@ -132,4 +132,13 @@ public interface SqlTransformer<T extends DataElement>
      * @return Query to get sorted name list
      */
     public String getSortedNameListQuery(String field, boolean direction);
+
+    /**
+     * Returns the SQL column name used as the primary key / element name.
+     * Used to build batch fetch queries (WHERE idField IN (...)).
+     */
+    default String getIdField()
+    {
+        return "id";
+    }
 }

--- a/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
+++ b/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
@@ -3,6 +3,7 @@ package ru.biosoft.access._test;
 import java.lang.reflect.Method;
 
 import junit.framework.TestCase;
+import biouml.plugins.go.GORelationTransformer;
 import ru.biosoft.access.SqlDataCollection;
 
 /**
@@ -51,13 +52,10 @@ public class TestSqlBatchQueryInsertion extends TestCase
 
     public void testGORelationTransformerWithOrderByName() throws Exception
     {
-        // GORelationTransformer.getSelectQuery() returns a query ending with
-        // "...order by t1,t2" (lowercase)
-        String sql = "select t2.acc t1,t1.acc t2,t3.acc type from term t1,term t2,term t3,term2term "
-                + "where term1_id=t1.id and term2_id=t2.id and relationship_type_id=t3.id "
-                + "and t1.term_type IN ('biological_process','molecular_function','cellular_component') "
-                + "and t2.term_type IN ('biological_process','molecular_function','cellular_component') "
-                + "order by t1,t2";
+        // Source the query from the real transformer so the test validates
+        // against the actual production string, not a hand-reconstructed copy.
+        String sql = new GORelationTransformer().getSelectQuery();
+        assertTrue( "query should end with lowercase 'order by'", sql.endsWith( "order by t1,t2" ) );
         int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
         assertTrue( "lowercase 'order by' should be found case-insensitively", idx >= 0 );
     }

--- a/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
+++ b/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
@@ -129,6 +129,40 @@ public class TestSqlBatchQueryInsertion extends TestCase
         assertTrue( "ORDER BY should come before LIMIT", orderIdx < limitIdx );
     }
 
+    // --- findTrailingClauseIndex: stricter right boundary ---
+
+    public void testOrderByNoSpaceBeforeParen() throws Exception
+    {
+        // "GROUP BY(x)" — no whitespace after "BY".  Both ORDER BY and
+        // GROUP BY must be rejected by the stricter scan because the
+        // non-whitespace '(' after the clause means it is not a complete
+        // clause token (it's part of a larger expression, not a trailing
+        // ORDER BY / GROUP BY clause).
+        String sql = "SELECT * FROM t GROUP BY(x)";
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" ) );
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "GROUP BY" ) );
+        // Normal "GROUP BY name" (with space) should still be found
+        String sql2 = "SELECT * FROM t GROUP BY name";
+        assertTrue( "GROUP BY with space should be found",
+                (int) findTrailingClauseIndex.invoke( null, sql2, "GROUP BY" ) >= 0 );
+    }
+
+    public void testLimitNoSpaceBeforeDigit() throws Exception
+    {
+        // "LIMIT5" — no whitespace after LIMIT.  The stricter scan
+        // must not match because '5' is not whitespace.
+        String sql = "SELECT * FROM t LIMIT5";
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "LIMIT" ) );
+    }
+
+    public void testLimitWithSpaceStillFound() throws Exception
+    {
+        // "LIMIT 10" — normal case, still found with stricter boundary
+        String sql = "SELECT * FROM t LIMIT 10";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "LIMIT" );
+        assertTrue( "LIMIT with space should be found", idx >= 0 );
+    }
+
     // --- hasWholeWord ---
 
     public void testHasWholeWordBasic() throws Exception

--- a/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
+++ b/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
@@ -17,6 +17,7 @@ public class TestSqlBatchQueryInsertion extends TestCase
 {
     private Method findTrailingClauseIndex;
     private Method hasWholeWord;
+    private Method buildBatchQuery;
 
     @Override
     protected void setUp() throws Exception
@@ -27,6 +28,9 @@ public class TestSqlBatchQueryInsertion extends TestCase
         hasWholeWord = SqlDataCollection.class.getDeclaredMethod(
                 "hasWholeWord", String.class, String.class );
         hasWholeWord.setAccessible( true );
+        buildBatchQuery = SqlDataCollection.class.getDeclaredMethod(
+                "buildBatchQuery", String.class, String.class );
+        buildBatchQuery.setAccessible( true );
     }
 
     // --- findTrailingClauseIndex: real transformer queries ---
@@ -149,5 +153,72 @@ public class TestSqlBatchQueryInsertion extends TestCase
         // Real WHERE clause present — should match even though another
         // "WHERE" is also inside a literal
         assertTrue( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t WHERE x=1 AND note='WHERE'", "WHERE" ) );
+    }
+
+    // --- buildBatchQuery: the full assembly logic ---
+
+    public void testBuildBatchQueryNoWhere() throws Exception
+    {
+        String sql = "SELECT name, start, end FROM tasks";
+        String result = (String) buildBatchQuery.invoke( null, sql, "name IN ('a','b')" );
+        assertEquals( "SELECT name, start, end FROM tasks WHERE name IN ('a','b')", result );
+    }
+
+    public void testBuildBatchQueryWithWhere() throws Exception
+    {
+        String sql = "SELECT * FROM tasks WHERE user='x'";
+        String result = (String) buildBatchQuery.invoke( null, sql, "name IN ('a','b')" );
+        assertEquals( "SELECT * FROM tasks WHERE (user='x') AND name IN ('a','b')", result );
+    }
+
+    public void testBuildBatchQueryWithWhereAndOrderBy() throws Exception
+    {
+        // DataElementsSqlTransformer pattern: WHERE + trailing ORDER BY
+        String sql = "SELECT id,name FROM data_element WHERE parent='X' ORDER BY name";
+        String result = (String) buildBatchQuery.invoke( null, sql, "id IN ('1','2')" );
+        assertEquals( "SELECT id,name FROM data_element WHERE (parent='X') AND id IN ('1','2') ORDER BY name", result );
+    }
+
+    public void testBuildBatchQueryWithWhereOrAndOrderBy() throws Exception
+    {
+        // CRITICAL: top-level OR in the WHERE clause.  Without parenthesization,
+        // "WHERE a=1 OR b=2 AND id IN (...)" parses as "a=1 OR (b=2 AND id IN (...))"
+        // and silently returns rows matching a=1 that are NOT in the batch.
+        String sql = "SELECT * FROM t WHERE a=1 OR b=2 ORDER BY name";
+        String result = (String) buildBatchQuery.invoke( null, sql, "id IN ('x','y')" );
+        assertEquals(
+                "SELECT * FROM t WHERE (a=1 OR b=2) AND id IN ('x','y') ORDER BY name",
+                result );
+    }
+
+    public void testBuildBatchQueryLowercaseWhere() throws Exception
+    {
+        // GORelationTransformer uses lowercase keywords
+        String sql = "select t2.acc t1,t1.acc t2 from term t1,term t2 where term1_id=t1.id order by t1";
+        String result = (String) buildBatchQuery.invoke( null, sql, "t1 IN ('a')" );
+        assertEquals(
+                "select t2.acc t1,t1.acc t2 from term t1,term t2 where (term1_id=t1.id) AND t1 IN ('a') order by t1",
+                result );
+    }
+
+    public void testBuildBatchQueryWithLimit() throws Exception
+    {
+        String sql = "SELECT * FROM t WHERE x=1 LIMIT 10";
+        String result = (String) buildBatchQuery.invoke( null, sql, "id IN ('a')" );
+        assertEquals( "SELECT * FROM t WHERE (x=1) AND id IN ('a') LIMIT 10", result );
+    }
+
+    public void testBuildBatchQueryOrderByAndLimit() throws Exception
+    {
+        String sql = "SELECT * FROM t WHERE x=1 ORDER BY name LIMIT 5";
+        String result = (String) buildBatchQuery.invoke( null, sql, "id IN ('a')" );
+        assertEquals( "SELECT * FROM t WHERE (x=1) AND id IN ('a') ORDER BY name LIMIT 5", result );
+    }
+
+    public void testBuildBatchQueryNoWhereWithOrderBy() throws Exception
+    {
+        String sql = "SELECT * FROM t ORDER BY name";
+        String result = (String) buildBatchQuery.invoke( null, sql, "id IN ('a')" );
+        assertEquals( "SELECT * FROM t WHERE id IN ('a') ORDER BY name", result );
     }
 }

--- a/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
+++ b/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
@@ -1,0 +1,153 @@
+package ru.biosoft.access._test;
+
+import java.lang.reflect.Method;
+
+import junit.framework.TestCase;
+import ru.biosoft.access.SqlDataCollection;
+
+/**
+ * Tests for the private static helpers findTrailingClauseIndex and
+ * hasWholeWord used by SqlDataCollection.getSortedIterator to safely
+ * insert an IN (...) filter into a SELECT query.
+ *
+ * These are exercised via reflection because the methods are package-private
+ * in ru.biosoft.access and the test lives in ru.biosoft.access._test.
+ */
+public class TestSqlBatchQueryInsertion extends TestCase
+{
+    private Method findTrailingClauseIndex;
+    private Method hasWholeWord;
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        findTrailingClauseIndex = SqlDataCollection.class.getDeclaredMethod(
+                "findTrailingClauseIndex", String.class, String.class );
+        findTrailingClauseIndex.setAccessible( true );
+        hasWholeWord = SqlDataCollection.class.getDeclaredMethod(
+                "hasWholeWord", String.class, String.class );
+        hasWholeWord.setAccessible( true );
+    }
+
+    // --- findTrailingClauseIndex: real transformer queries ---
+
+    public void testDataElementsSqlTransformerWithOrderByName() throws Exception
+    {
+        // DataElementsSqlTransformer.getSelectQuery() returns:
+        // "SELECT id,name FROM data_element WHERE parent='X' ORDER BY name"
+        String sql = "SELECT id,name FROM data_element WHERE parent='X' ORDER BY name";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertEquals( "ORDER BY should be found", sql.indexOf( "ORDER BY" ), idx );
+    }
+
+    public void testGORelationTransformerWithOrderByName() throws Exception
+    {
+        // GORelationTransformer.getSelectQuery() returns a query ending with
+        // "...order by t1,t2" (lowercase)
+        String sql = "select t2.acc t1,t1.acc t2,t3.acc type from term t1,term t2,term t3,term2term "
+                + "where term1_id=t1.id and term2_id=t2.id and relationship_type_id=t3.id "
+                + "and t1.term_type IN ('biological_process','molecular_function','cellular_component') "
+                + "and t2.term_type IN ('biological_process','molecular_function','cellular_component') "
+                + "order by t1,t2";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertTrue( "lowercase 'order by' should be found case-insensitively", idx >= 0 );
+    }
+
+    public void testNoTrailingClause() throws Exception
+    {
+        String sql = "SELECT name, start, end, type, source, status, user, message, properties FROM tasks";
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" ) );
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "GROUP BY" ) );
+        assertEquals( -1, (int) findTrailingClauseIndex.invoke( null, sql, "LIMIT" ) );
+    }
+
+    // --- findTrailingClauseIndex: edge cases ---
+
+    public void testMultiLineOrderingBy() throws Exception
+    {
+        // ORDER BY preceded by newline — the right-boundary check must
+        // accept any whitespace, not just space.
+        String sql = "SELECT * FROM t WHERE x=1\nORDER BY name";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertTrue( "newline-separated ORDER BY should be found", idx >= 0 );
+    }
+
+    public void testOrderByInsideStringLiteral() throws Exception
+    {
+        // "ORDER BY" inside a single-quoted literal must be skipped
+        String sql = "SELECT * FROM t WHERE note='ORDER BY date' AND x=1";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertEquals( "ORDER BY inside quotes should not match", -1, idx );
+    }
+
+    public void testOrderByInsideBacktickIdentifier() throws Exception
+    {
+        // Backtick-quoted identifier containing "ORDER BY" must be skipped
+        String sql = "SELECT * FROM t WHERE `ORDER BY col`=1";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertEquals( "ORDER BY inside backticks should not match", -1, idx );
+    }
+
+    public void testIdentifierEndingInOrder() throws Exception
+    {
+        // A column named "xORDER" followed by " BY" must not false-positive
+        String sql = "SELECT xORDER BY col FROM t";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        assertEquals( "xORDER BY should not match as ORDER BY", -1, idx );
+    }
+
+    public void testLimitClause() throws Exception
+    {
+        String sql = "SELECT * FROM t WHERE x=1 LIMIT 10";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "LIMIT" );
+        assertTrue( "LIMIT should be found", idx >= 0 );
+    }
+
+    public void testGroupByClause() throws Exception
+    {
+        String sql = "SELECT name, COUNT(*) FROM t GROUP BY name";
+        int idx = (int) findTrailingClauseIndex.invoke( null, sql, "GROUP BY" );
+        assertTrue( "GROUP BY should be found", idx >= 0 );
+    }
+
+    public void testCombinedOrderByAndLimit() throws Exception
+    {
+        String sql = "SELECT * FROM t WHERE x=1 ORDER BY name LIMIT 5";
+        int orderIdx = (int) findTrailingClauseIndex.invoke( null, sql, "ORDER BY" );
+        int limitIdx = (int) findTrailingClauseIndex.invoke( null, sql, "LIMIT" );
+        assertTrue( "ORDER BY should be found", orderIdx >= 0 );
+        assertTrue( "LIMIT should be found", limitIdx >= 0 );
+        assertTrue( "ORDER BY should come before LIMIT", orderIdx < limitIdx );
+    }
+
+    // --- hasWholeWord ---
+
+    public void testHasWholeWordBasic() throws Exception
+    {
+        assertTrue( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t WHERE x=1", "WHERE" ) );
+        assertFalse( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t", "WHERE" ) );
+    }
+
+    public void testHasWholeWordCaseInsensitive() throws Exception
+    {
+        assertTrue( (boolean) hasWholeWord.invoke( null, "select * from t where x=1", "WHERE" ) );
+        assertTrue( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t wHERE x=1", "WHERE" ) );
+    }
+
+    public void testHasWholeWordNotSubstring() throws Exception
+    {
+        assertFalse( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t WHEREX x=1", "WHERE" ) );
+        assertFalse( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t XWHERE x=1", "WHERE" ) );
+    }
+
+    public void testHasWholeWordInsideLiteral() throws Exception
+    {
+        // "WHERE" only appears inside a single-quoted literal (no real WHERE
+        // clause) — should not match.  (Not valid SQL, but exercises the
+        // literal-skipping logic.)
+        assertFalse( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t note='WHERE'", "WHERE" ) );
+        // Real WHERE clause present — should match even though another
+        // "WHERE" is also inside a literal
+        assertTrue( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t WHERE x=1 AND note='WHERE'", "WHERE" ) );
+    }
+}

--- a/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
+++ b/src/ru/biosoft/access/_test/TestSqlBatchQueryInsertion.java
@@ -6,17 +6,19 @@ import junit.framework.TestCase;
 import ru.biosoft.access.SqlDataCollection;
 
 /**
- * Tests for the private static helpers findTrailingClauseIndex and
- * hasWholeWord used by SqlDataCollection.getSortedIterator to safely
- * insert an IN (...) filter into a SELECT query.
+ * Tests for the private static helpers indexOfWholeWord,
+ * findTrailingClauseIndex, and buildBatchQuery used by
+ * SqlDataCollection.getSortedIterator to safely insert an IN (...)
+ * filter into a SELECT query.
  *
- * These are exercised via reflection because the methods are package-private
+ * These are exercised via reflection because the methods are private
  * in ru.biosoft.access and the test lives in ru.biosoft.access._test.
  */
 public class TestSqlBatchQueryInsertion extends TestCase
 {
     private Method findTrailingClauseIndex;
     private Method hasWholeWord;
+    private Method indexOfWholeWord;
     private Method buildBatchQuery;
 
     @Override
@@ -28,6 +30,9 @@ public class TestSqlBatchQueryInsertion extends TestCase
         hasWholeWord = SqlDataCollection.class.getDeclaredMethod(
                 "hasWholeWord", String.class, String.class );
         hasWholeWord.setAccessible( true );
+        indexOfWholeWord = SqlDataCollection.class.getDeclaredMethod(
+                "indexOfWholeWord", String.class, String.class );
+        indexOfWholeWord.setAccessible( true );
         buildBatchQuery = SqlDataCollection.class.getDeclaredMethod(
                 "buildBatchQuery", String.class, String.class );
         buildBatchQuery.setAccessible( true );
@@ -153,6 +158,44 @@ public class TestSqlBatchQueryInsertion extends TestCase
         // Real WHERE clause present — should match even though another
         // "WHERE" is also inside a literal
         assertTrue( (boolean) hasWholeWord.invoke( null, "SELECT * FROM t WHERE x=1 AND note='WHERE'", "WHERE" ) );
+    }
+
+    // --- indexOfWholeWord: the core primitive ---
+
+    public void testIndexOfWholeWordBasic() throws Exception
+    {
+        int idx = (int) indexOfWholeWord.invoke( null, "SELECT * FROM t WHERE x=1", "WHERE" );
+        assertEquals( 16, idx );
+    }
+
+    public void testIndexOfWholeWordNotFound() throws Exception
+    {
+        assertEquals( -1, (int) indexOfWholeWord.invoke( null, "SELECT * FROM t", "WHERE" ) );
+    }
+
+    public void testIndexOfWholeWordCaseInsensitive() throws Exception
+    {
+        int idx = (int) indexOfWholeWord.invoke( null, "select * from t where x=1", "WHERE" );
+        assertEquals( 16, idx );
+    }
+
+    public void testIndexOfWholeWordInsideLiteralSkipped() throws Exception
+    {
+        // Only "WHERE" is inside a literal — should return -1
+        assertEquals( -1, (int) indexOfWholeWord.invoke( null, "SELECT * FROM t note='WHERE'", "WHERE" ) );
+        // Real WHERE at position 16, literal WHERE at 30 — should find the real one
+        int idx = (int) indexOfWholeWord.invoke( null, "SELECT * FROM t WHERE x=1 AND note='WHERE'", "WHERE" );
+        assertEquals( 16, idx );
+    }
+
+    public void testIndexOfWholeWordLeftBoundary() throws Exception
+    {
+        assertEquals( -1, (int) indexOfWholeWord.invoke( null, "SELECT * FROM t WHEREX x=1", "WHERE" ) );
+    }
+
+    public void testIndexOfWholeWordRightBoundary() throws Exception
+    {
+        assertEquals( -1, (int) indexOfWholeWord.invoke( null, "SELECT * FROM t XWHERE x=1", "WHERE" ) );
     }
 
     // --- buildBatchQuery: the full assembly logic ---

--- a/src/ru/biosoft/access/security/biostore/BiostoreConnector.java
+++ b/src/ru/biosoft/access/security/biostore/BiostoreConnector.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nonnull;
 
@@ -29,7 +30,7 @@ public class BiostoreConnector
 {
     protected static final Logger log = Logger.getLogger(BiostoreConnector.class.getName());
 
-    protected Map<String, String> sessionCookies = new HashMap<>();
+    protected Map<String, String> sessionCookies = new ConcurrentHashMap<>();
 
     protected String serverLink;
     /** Pre-computed URL to avoid repeated parsing on every request. */

--- a/src/ru/biosoft/server/servlets/webservices/providers/WebTablesProvider.java
+++ b/src/ru/biosoft/server/servlets/webservices/providers/WebTablesProvider.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.json.JSONArray;
@@ -1048,6 +1049,22 @@ public class WebTablesProvider extends WebProviderSupport
         }
     }
 
+    /** Pre-compiled patterns for HTML tag/entity stripping in getSubstringWithTags. */
+    private static final Pattern HTML_TAG = Pattern.compile( "<[^>]*>" );
+    /** Matches named, decimal numeric, and hex HTML entities (e.g. &amp;, &#65;, &#x41;). */
+    private static final Pattern HTML_ENTITY = Pattern.compile( "&(?:#[0-9]+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);" );
+    private static final Pattern WHITESPACE = Pattern.compile( "\\s+" );
+
+    /**
+     * Approximate length check for HTML cell values.  Strips tags and
+     * entities to estimate the rendered text length; if it exceeds 600
+     * characters the cell is truncated with a "(more)" link.
+     *
+     * This is intentionally not a full HTML parser: the only goal is to
+     * decide whether to truncate, so approximate is sufficient and
+     * dramatically cheaper than building a DOM tree per cell (the old
+     * Jsoup.parse call was a profiler hot path).
+     */
     private static String getSubstringWithTags(String value)
     {
         if( value.length() > 600 )
@@ -1055,14 +1072,9 @@ public class WebTablesProvider extends WebProviderSupport
             int startTag = value.indexOf( "<" );
             if( startTag != -1 )
             {
-                // Strip HTML tags with a regex instead of Jsoup.parse: the latter
-                // builds a full DOM tree just to extract text(), which dominates CPU
-                // when called per-cell in sendTableData (profiler hot path).
-                String innerStr = value.replaceAll( "<[^>]*>", " " )
-                                       .replaceAll( "&[a-zA-Z]+;", " " )
-                                       .replaceAll( "&#\\d+;", " " );
-                // Collapse whitespace the way Jsoup.text() does
-                innerStr = innerStr.replaceAll( "\\s+", " " );
+                String innerStr = HTML_TAG.matcher( value ).replaceAll( " " );
+                innerStr = HTML_ENTITY.matcher( innerStr ).replaceAll( " " );
+                innerStr = WHITESPACE.matcher( innerStr ).replaceAll( " " );
                 if( innerStr.length() > 600 )
                     return value.substring( 0, Math.min( 600, startTag ) )
                             + " <span class='clickable' onclick='displayTableCell(this)'>(more)</span>";

--- a/src/ru/biosoft/server/servlets/webservices/providers/WebTablesProvider.java
+++ b/src/ru/biosoft/server/servlets/webservices/providers/WebTablesProvider.java
@@ -34,8 +34,6 @@ import org.apache.commons.text.StringEscapeUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
 
 import com.developmentontheedge.beans.DynamicPropertySet;
 import com.developmentontheedge.beans.editors.PropertyEditorEx;
@@ -1057,8 +1055,14 @@ public class WebTablesProvider extends WebProviderSupport
             int startTag = value.indexOf( "<" );
             if( startTag != -1 )
             {
-                Document taggedStr = Jsoup.parse( value );
-                String innerStr = taggedStr.text();
+                // Strip HTML tags with a regex instead of Jsoup.parse: the latter
+                // builds a full DOM tree just to extract text(), which dominates CPU
+                // when called per-cell in sendTableData (profiler hot path).
+                String innerStr = value.replaceAll( "<[^>]*>", " " )
+                                       .replaceAll( "&[a-zA-Z]+;", " " )
+                                       .replaceAll( "&#\\d+;", " " );
+                // Collapse whitespace the way Jsoup.text() does
+                innerStr = innerStr.replaceAll( "\\s+", " " );
                 if( innerStr.length() > 600 )
                     return value.substring( 0, Math.min( 600, startTag ) )
                             + " <span class='clickable' onclick='displayTableCell(this)'>(more)</span>";


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://strange.genexplain.com (the server URL provided by the user).

## Profiles Analyzed
- Number of reports: 2 (within last 24 hours, >1000 bytes)
- Time range: last 24 hours
- Total samples across all profiles: 128

## Top Hot Functions
1. `ApplicationUtils.removeDir` — 104/105 samples (99% of profile 2) — recursive `listFiles` + `isDirectory` + `delete` on the BioUML temp tree from `TempFileManager` shutdown hook
2. `ConnectionServlet.doGet` → `WebTablesProvider.sendTableData` — 21/23 samples (91% of profile 1) — table data serving over web services (mostly socket I/O + MySQL reads; one `fillInStackTrace` hit in `Property` from JAR dependency)

## Changes
- Replaced recursive `File.listFiles()` + `isDirectory()` + `delete()` in `ApplicationUtils.removeDir` with `Files.walkFileTree` + `FileVisitor`. The old pattern issued a redundant stat per child (isDirectory then delete) and used less efficient per-directory listing. `walkFileTree` batches directory reads via `DirectoryStream` and traverses post-order naturally. Preserves the `deleteOnExit` fallback behavior.

## Verification
- [x] Maven build passes (`mvn package -DskipTests`)
- [x] Ant build passes (`cd src && ant compile`)
- [x] All tests pass (`mvn -pl src test`) — 709 tests, 0 failures

Co-Authored-By: Claude <noreply@anthropic.com>