### PR TITLE
feat(servermonitor): persist sub-process observations to a retrievable log

### DIFF
--- a/.claude/skills/profiler-review/SKILL.md
+++ b/.claude/skills/profiler-review/SKILL.md
@@ -97,13 +97,18 @@ bash .claude/skills/profiler-review/scripts/fetch_profile.sh subprocess --slow-o
 ```
 
 This prints a table: `timestamp  [SLOW] pid=… age=…s  <full command line>`.
-Interpretation:
-- **Records present** → part of the task's wall-clock time is in an external
-  process. The CPU profile under-counts the JVM's real cost; the slow
-  sub-process (full `cmdline`) is the thing to investigate (script-level
-  profiling, I/O, missing indexes).
-- **No records / "work was in-JVM"** → the time is genuinely in the JVM;
-  proceed with the normal CPU-profile hot-path analysis (Step 2).
+Interpretation (the log is *correlational* evidence, not proof of causation —
+an external process being alive is not proof the task is blocked on it, and its
+absence is not proof the work was in-JVM):
+- **Records present, and their timestamps line up with the profile window** →
+  a plausible explanation for an "idle-looking" CPU profile is that the task's
+  wall-clock time was spent in an external process. Worth investigating the
+  slow sub-process (script-level profiling, I/O, missing indexes) before
+  concluding the JVM is the bottleneck — but confirm the overlap rather than
+  assuming it.
+- **No records / "work was in-JVM"** → no long-running external process was
+  *observed* during that window; the in-JVM hot-path analysis (Step 2) is the
+  better starting point, but a short-lived subprocess may have gone unrecorded.
 
 Filter to a profile's window if needed: `--since <epochMillis> --until <epochMillis>`
 (from the profile's `metadata.startTime` / `endTime`). `--slow-only` keeps only
@@ -220,7 +225,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - **No recent profiles** (empty list from `action=list`): Report that the server has no profiling data from the last 24 hours with size >1000 bytes. Check that the monitoring plugin is running and profiling is enabled.
 - **Empty profile** (0 samples): No optimizations needed; report that the server has profiling data but no samples were captured.
 - **Native frames only** (e.g., `__pthread_cond_timedwait`): The hot path is in native code or waiting on a condition variable — suggest checking for busy-wait loops or excessive thread synchronization in Java code.
-- **Profile looks almost entirely idle/park but the task is slow**: The work is likely in an **external sub-process** (perl/R/nextflow). Check the sub-process log (Step 1.5) — if a SLOW record with a full `cmdline` lines up with the profile's time window, the bottleneck is in that external program, not the JVM.
+- **Profile looks almost entirely idle/park but the task is slow**: The work *may* be in an **external sub-process** (perl/R/nextflow). Check the sub-process log (Step 1.5) — if a SLOW record's timestamp lines up with the profile's time window, that external program is a likely candidate for the bottleneck (confirm the overlap before concluding it, not the JVM).
 - **Tree/Traces not available**: Only Collapsed Stacks are populated — focus analysis on the top 100 collapsed chains.
 - **Profile from a specific task**: The metadata section shows task type — tailor optimizations to the task domain (diagram rendering, simulation, data import, etc.).
 - **Small profiles** (≤1000 bytes): Likely trivial or incomplete captures — skip these in the filter; they won't yield meaningful optimizations.

--- a/.claude/skills/profiler-review/SKILL.md
+++ b/.claude/skills/profiler-review/SKILL.md
@@ -83,6 +83,36 @@ Save each profile's content to a separate temporary file (e.g., `profile_1.colla
 
 **If no profiles match** (empty list): report that the server has no recent profiling data and stop.
 
+### Step 1.5: Fetch the Sub-Process Log (external scripts)
+
+async-profiler only samples the JVM. If a task's time is spent in an external
+script (perl / R / nextflow / git), the CPU profile looks nearly empty (just
+futex/park waits). The server's `SubProcessMonitor` records every long-running
+external descendant process to a persistent log (`subprocesses.jsonl`) and
+exposes it via `action=subProcessLog`. **Always fetch it** so a profile that
+"looks idle" can be cross-checked against off-JVM work.
+
+```bash
+bash .claude/skills/profiler-review/scripts/fetch_profile.sh subprocess --slow-only "$PROFILE_SERVER_URL"
+```
+
+This prints a table: `timestamp  [SLOW] pid=… age=…s  <full command line>`.
+Interpretation:
+- **Records present** → part of the task's wall-clock time is in an external
+  process. The CPU profile under-counts the JVM's real cost; the slow
+  sub-process (full `cmdline`) is the thing to investigate (script-level
+  profiling, I/O, missing indexes).
+- **No records / "work was in-JVM"** → the time is genuinely in the JVM;
+  proceed with the normal CPU-profile hot-path analysis (Step 2).
+
+Filter to a profile's window if needed: `--since <epochMillis> --until <epochMillis>`
+(from the profile's `metadata.startTime` / `endTime`). `--slow-only` keeps only
+scans that contained an over-threshold process.
+
+> Note: the `subProcessLog` action requires the server to be running a build
+> that includes the persistent sub-process log (this PR). Older deployments
+> return an error, which the script degrades to "0 records".
+
 ### Step 2: Analyze Profile Output
 
 Aggregate analysis across all fetched profiles. Focus on these sections per profile:
@@ -190,6 +220,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - **No recent profiles** (empty list from `action=list`): Report that the server has no profiling data from the last 24 hours with size >1000 bytes. Check that the monitoring plugin is running and profiling is enabled.
 - **Empty profile** (0 samples): No optimizations needed; report that the server has profiling data but no samples were captured.
 - **Native frames only** (e.g., `__pthread_cond_timedwait`): The hot path is in native code or waiting on a condition variable — suggest checking for busy-wait loops or excessive thread synchronization in Java code.
+- **Profile looks almost entirely idle/park but the task is slow**: The work is likely in an **external sub-process** (perl/R/nextflow). Check the sub-process log (Step 1.5) — if a SLOW record with a full `cmdline` lines up with the profile's time window, the bottleneck is in that external program, not the JVM.
 - **Tree/Traces not available**: Only Collapsed Stacks are populated — focus analysis on the top 100 collapsed chains.
 - **Profile from a specific task**: The metadata section shows task type — tailor optimizations to the task domain (diagram rendering, simulation, data import, etc.).
 - **Small profiles** (≤1000 bytes): Likely trivial or incomplete captures — skip these in the filter; they won't yield meaningful optimizations.

--- a/.claude/skills/profiler-review/scripts/fetch_profile.sh
+++ b/.claude/skills/profiler-review/scripts/fetch_profile.sh
@@ -182,8 +182,67 @@ except:
     fi
     ;;
 
+  subprocess)
+    # Fetch the persistent sub-process observation log (action=subProcessLog).
+    # Optional extra args before the server URL: --slow-only, --since <ms>, --until <ms>
+    # Prints a human-readable table of long-running external processes (perl/R/nextflow/...)
+    # recorded over time — the complement to the CPU profile, which only sees the JVM.
+    SP_EXTRA=""
+    SLOW_ONLY=""
+    SINCE=""
+    UNTIL=""
+    while [[ $# -gt 1 ]]; do
+      case "$1" in
+        --slow-only) SLOW_ONLY="&slowOnly=true"; shift ;;
+        --since)     SINCE="$2"; shift 2 ;;
+        --until)     UNTIL="$2"; shift 2 ;;
+        *)           shift ;;
+      esac
+    done
+    # Rebuild the query string, then drop the server URL from $@ handling.
+    SERVER_URL="${PROFILE_SERVER_URL:-${1:-}}"
+    [[ -n "$SINCE" ]] && SINCE="&since=${SINCE}"
+    [[ -n "$UNTIL" ]] && UNTIL="&until=${UNTIL}"
+    SUB_URL="${SERVER_URL%/}/biouml/support/profile?action=subProcessLog&user=${MONITORING_USER}&pass=${MONITORING_PASS}${SLOW_ONLY}${SINCE}${UNTIL}"
+    echo "Fetching sub-process log from: ${SUB_URL}" >&2
+    echo "" >&2
+
+    curl -s -L --max-time 120 "$SUB_URL" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.stdout.write(sys.stdin.read() if not sys.stdin.closed else '')
+    sys.exit(1)
+
+def get_value(d):
+    if isinstance(d, dict):
+        if 'value' in d and isinstance(d['value'], dict):
+            return d['value']
+        return d
+    return {}
+
+v = get_value(data)
+records = v.get('records', [])
+path = v.get('path', '')
+count = v.get('count', len(records))
+print(f'=== Sub-process log ({count} records)  [{path}] ===')
+if not records:
+    print('  (no sub-processes recorded — work was in-JVM, or log is empty)')
+    sys.exit(0)
+import datetime
+for rec in records:
+    ts = rec.get('timestamp', 0)
+    when = datetime.datetime.fromtimestamp(ts/1000.0).strftime('%Y-%m-%d %H:%M:%S') if ts else '?'
+    subs = rec.get('subProcesses', [])
+    for sp in subs:
+        flag = 'SLOW ' if sp.get('slow') else ''
+        print(f\"{when}  {flag}pid={sp.get('pid')} age={sp.get('ageSeconds')}s  {sp.get('command')}\")
+"
+    ;;
+
   *)
-    echo "ERROR: unknown action '${ACTION}'. Use: list, get, summary" >&2
+    echo "ERROR: unknown action '${ACTION}'. Use: list, get, summary, subprocess" >&2
     exit 1
     ;;
 esac

--- a/.claude/skills/profiler-review/scripts/fetch_profile.sh
+++ b/.claude/skills/profiler-review/scripts/fetch_profile.sh
@@ -209,10 +209,13 @@ except:
 
     curl -s -L --max-time 120 "$SUB_URL" | python3 -c "
 import sys, json
+# Read the whole response first, then parse — json.load(sys.stdin) would consume
+# the stream, so a failed parse leaves nothing to echo back.
+raw = sys.stdin.read()
 try:
-    data = json.load(sys.stdin)
+    data = json.loads(raw)
 except json.JSONDecodeError:
-    sys.stdout.write(sys.stdin.read() if not sys.stdin.closed else '')
+    sys.stdout.write(raw)
     sys.exit(1)
 
 def get_value(d):

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -606,7 +606,8 @@ public class MonitoringService {
      *   <li>Two-component: api-key, api-token, access-key, private-key,
      *       client-secret, session-token, refresh-token, auth-token,
      *       bearer-token, http-token</li>
-     *   <li>Three-component: o-auth-token (from OAuthToken)</li>
+     *   <li>Three-component: o-auth-token, as produced by the camelCase
+     *       tokenizer for the argument name {@code OAuthToken}</li>
      * </ul>
      */
     private static boolean isStrongCredential(String bareKey) {

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -603,8 +603,10 @@ public class MonitoringService {
      * <p>Recognized strong credentials:
      * <ul>
      *   <li>Single component: password, passwd, pwd, token, secret, credential</li>
-     *   <li>Two-component: api-key, access-key, private-key, client-secret,
-     *       session-token, refresh-token, auth-token, bearer-token</li>
+     *   <li>Two-component: api-key, api-token, access-key, private-key,
+     *       client-secret, session-token, refresh-token, auth-token,
+     *       bearer-token, http-token</li>
+     *   <li>Three-component: o-auth-token (from OAuthToken)</li>
      * </ul>
      */
     private static boolean isStrongCredential(String bareKey) {
@@ -618,13 +620,19 @@ public class MonitoringService {
                     || p.equals("credential");
         }
         return isExactCompound(parts, "api", "key")
+                || isExactCompound(parts, "api", "token")
                 || isExactCompound(parts, "access", "key")
                 || isExactCompound(parts, "private", "key")
                 || isExactCompound(parts, "client", "secret")
                 || isExactCompound(parts, "session", "token")
                 || isExactCompound(parts, "refresh", "token")
                 || isExactCompound(parts, "auth", "token")
-                || isExactCompound(parts, "bearer", "token");
+                || isExactCompound(parts, "bearer", "token")
+                // "OAuthToken" splits to [o, auth, token] (the first pass
+                // separates "O" from "Auth" at the lower→upper boundary).
+                || isExactCompound(parts, "o", "auth", "token")
+                // "HTTPToken" splits to [http, token].
+                || isExactCompound(parts, "http", "token");
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -6,8 +6,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -73,6 +75,19 @@ public class MonitoringService {
     private static final int MAX_SUB_PROCESS_LOG_LINES = 5000;
     /** Maximum age (ms) of a sub-process log line before it is purged. */
     private static final long MAX_SUB_PROCESS_LOG_AGE = 7L * 24 * 60 * 60 * 1000; // 7 days
+    /**
+     * Purge the log at most once every this long (ms) unless the line cap is
+     * exceeded. The age check needs a full scan, so it must not run on every
+     * monitor cycle — only periodically, or when the log is already over the cap.
+     */
+    private static final long SUB_PROCESS_LOG_PURGE_INTERVAL = 10L * 60L * 1000L; // 10 min
+
+    // In-memory record count for the sub-process log, so the status endpoint
+    // does not need to scan the whole file. Approximate after an external
+    // edit; recomputed exactly on every append.
+    private int subProcessLogCount = -1;
+    /** Last time the sub-process log was fully scanned for purging. */
+    private long lastSubProcessLogPurgeTime = 0;
 
     // Guards append/rewrite of the sub-process log (single monitor thread writes,
     // but the API can read concurrently; keep the file in a consistent state).
@@ -224,9 +239,11 @@ public class MonitoringService {
      * persistent log. Each line is a self-contained record:
      * <pre>{"timestamp":..., "checkIntervalSec":..., "subProcesses":[{"pid":..,"ageSeconds":..,"slow":..,"command":..}, ...]}</pre>
      *
-     * <p>Writing is serialized against {@link #subProcessLogLock}; a rewrite is
-     * performed (under the same lock) when the file exceeds the size/age limits
-     * so the log stays bounded.
+     * <p>Writing is serialized against {@link #subProcessLogLock}. The append is
+     * the only per-scan I/O (the hot path never rewrites the file); a full
+     * rewrite/compact runs only when the line cap is exceeded or at most every
+     * {@link #SUB_PROCESS_LOG_PURGE_INTERVAL}, so the age bound is enforced
+     * without scanning on every cycle.
      */
     private void appendSubProcessLog(List<SubProcessMonitor.SubProcess> subs, long timestamp) {
         File logFile = getSubProcessLogFile();
@@ -235,27 +252,27 @@ public class MonitoringService {
         }
         synchronized (subProcessLogLock) {
             try {
-                // Purge old / excess lines first (cheap: only read when the
-                // file is already large or the oldest line is past its age).
-                if (logFile.exists() && logFile.length() > 0) {
-                    long now = System.currentTimeMillis();
-                    File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
-                    boolean purged = purgeSubProcessLog(logFile, tmp, now);
-                    if (purged) {
-                        // tmp now holds the pruned content; rename over the original.
-                        if (!logFile.delete() || !tmp.renameTo(logFile)) {
-                            tmp.delete();
-                        }
-                    } else {
-                        tmp.delete();
-                    }
-                }
-
+                // Append first — the hot path must never scan the whole file.
                 String line = buildSubProcessRecord(subs, timestamp);
                 try (BufferedWriter writer = new BufferedWriter(
                         new java.io.OutputStreamWriter(new FileOutputStream(logFile, true), StandardCharsets.UTF_8))) {
                     writer.write(line);
                     writer.newLine();
+                }
+
+                long now = System.currentTimeMillis();
+                if (subProcessLogCount < 0) {
+                    subProcessLogCount = countSubProcessLogLines(logFile);
+                }
+                subProcessLogCount++;
+
+                // Purge only when the line cap is exceeded or the age scan is
+                // due. The age check is a full scan, so it must not run on
+                // every monitor cycle.
+                boolean overCap = subProcessLogCount > MAX_SUB_PROCESS_LOG_LINES;
+                boolean ageDue = now - lastSubProcessLogPurgeTime >= SUB_PROCESS_LOG_PURGE_INTERVAL;
+                if (overCap || ageDue) {
+                    purgeAndCompactSubProcessLog(logFile, now);
                 }
             } catch (Exception e) {
                 log.log(Level.WARNING, "Error appending sub-process log " + logFile.getAbsolutePath(), e);
@@ -264,23 +281,31 @@ public class MonitoringService {
     }
 
     /**
-     * Rewrite the sub-process log, dropping lines older than
-     * {@link #MAX_SUB_PROCESS_LOG_AGE} and keeping only the most recent
-     * {@link #MAX_SUB_PROCESS_LOG_LINES}. Returns true if any line was dropped
-     * (i.e. the file content actually changed).
+     * Full scan of the sub-process log: drop lines older than
+     * {@link #MAX_SUB_PROCESS_LOG_AGE} and malformed lines (no parseable
+     * timestamp, which can't be bounded by age), keep the most recent
+     * {@link #MAX_SUB_PROCESS_LOG_LINES}, and atomically replace the file.
+     * Updates the in-memory line count.
      */
-    private boolean purgeSubProcessLog(File logFile, File tmp, long now) throws IOException {
+    private void purgeAndCompactSubProcessLog(File logFile, long now) throws IOException {
+        lastSubProcessLogPurgeTime = now;
+        if (!logFile.exists() || logFile.length() == 0) {
+            subProcessLogCount = 0;
+            return;
+        }
+
         // Pass 1: read the log, dropping lines older than MAX_SUB_PROCESS_LOG_AGE.
         List<String> kept = new ArrayList<>();
-        int total = 0;
         try (java.io.BufferedReader reader = new java.io.BufferedReader(
                 new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 if (line.trim().isEmpty()) continue;
-                total++;
                 long ts = extractTimestamp(line);
-                boolean tooOld = ts > 0 && (now - ts) > MAX_SUB_PROCESS_LOG_AGE;
+                // A line with no parseable timestamp is malformed: it can never
+                // be dropped by age, so it would grow the log forever. Drop it.
+                if (ts <= 0) continue;
+                boolean tooOld = (now - ts) > MAX_SUB_PROCESS_LOG_AGE;
                 if (!tooOld) {
                     kept.add(line);
                 }
@@ -292,10 +317,15 @@ public class MonitoringService {
         if (excess > 0) {
             kept.subList(0, excess).clear();
         }
+        subProcessLogCount = kept.size();
 
-        boolean changed = (kept.size() != total);
-        if (changed) {
-            // Pass 2: rewrite the pruned content to tmp (caller renames tmp over logFile).
+        // Pass 2: rewrite the pruned content to a temp file, then atomically
+        // move it over the original so a reader never sees a partial/truncated
+        // file (the old delete-then-rename left a window where the log was
+        // missing). The move is atomic on the same filesystem; fall back to a
+        // plain rename if the platform doesn't support ATOMIC_MOVE.
+        File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
+        try {
             try (BufferedWriter tw = new BufferedWriter(
                     new java.io.OutputStreamWriter(new FileOutputStream(tmp), StandardCharsets.UTF_8))) {
                 for (String l : kept) {
@@ -303,8 +333,35 @@ public class MonitoringService {
                     tw.newLine();
                 }
             }
+            try {
+                Files.move(tmp.toPath(), logFile.toPath(),
+                        StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp.toPath(), logFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+        } finally {
+            // Best-effort delete if the move did not consume the temp file.
+            if (tmp.exists()) {
+                tmp.delete();
+            }
         }
-        return changed;
+    }
+
+    /**
+     * Count the non-empty lines in the sub-process log (full scan). Used once
+     * at startup to seed the in-memory count; steady-state appends maintain it
+     * incrementally so the status endpoint never scans the file.
+     */
+    private int countSubProcessLogLines(File logFile) throws IOException {
+        int n = 0;
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (!line.trim().isEmpty()) n++;
+            }
+        }
+        return n;
     }
 
     /**
@@ -331,6 +388,8 @@ public class MonitoringService {
      */
     private String buildSubProcessRecord(List<SubProcessMonitor.SubProcess> subs, long timestamp) {
         JSONObject record = new JSONObject();
+        // Version the record schema so future readers can detect layout changes.
+        record.put("version", 1);
         record.put("timestamp", timestamp);
         record.put("checkIntervalSec", config.getCheckInterval());
         record.put("thresholdSec", config.getSubProcessThreshold());
@@ -342,11 +401,62 @@ public class MonitoringService {
             o.put("pid", sp.pid);
             o.put("ageSeconds", sp.ageSeconds);
             o.put("slow", sp.slow);
-            o.put("command", sp.command);
+            // The log is persisted (up to 7 days) and readable through the API,
+            // so command lines are redacted: an external script can carry
+            // credentials on its command line (--password=..., --token=...),
+            // which must not be written to disk or exposed by the endpoint.
+            o.put("command", redactCommand(sp.command));
             arr.put(o);
         }
         record.put("subProcesses", arr);
         return record.toString();
+    }
+
+    /**
+     * Redact secret-looking arguments from a command line before it is
+     * persisted to the sub-process log. A token is redacted if its name
+     * (the argument before {@code =}, lowercased) matches a known
+     * credential key, or if the argument is {@code --key=value} where the key
+     * itself looks like a credential. The value is replaced with {@code ***}
+     * while the key is kept, so the record stays useful for analysis.
+     */
+    private static String redactCommand(String command) {
+        if (command == null || command.isEmpty()) {
+            return command;
+        }
+        String[] parts = command.split("\\s+", -1);
+        boolean changed = false;
+        for (int i = 0; i < parts.length; i++) {
+            String p = parts[i];
+            int eq = p.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            String key = p.substring(0, eq);
+            String bare = key.startsWith("-") ? key.substring(key.lastIndexOf('-') + 1) : key;
+            if (looksLikeSecretKey(bare)) {
+                parts[i] = key + "=***";
+                changed = true;
+            }
+        }
+        return changed ? String.join(" ", parts) : command;
+    }
+
+    /** True if a command-line argument key looks like a credential. */
+    private static boolean looksLikeSecretKey(String key) {
+        String k = key.toLowerCase();
+        if (k.isEmpty()) {
+            return false;
+        }
+        // Common credential key stems.
+        if (k.contains("password") || k.contains("passwd") || k.contains("pwd")
+                || k.contains("token") || k.contains("secret") || k.contains("apikey")
+                || k.contains("api_key") || k.contains("accesskey") || k.contains("access_key")
+                || k.contains("privatekey") || k.contains("private_key")) {
+            return true;
+        }
+        // AWS-style keys are 20-char base64; flag anything that long.
+        return k.length() >= 20;
     }
 
     /**
@@ -393,25 +503,28 @@ public class MonitoringService {
     }
 
     /**
-     * Total number of records in the sub-process log (0 if none).
+     * Total number of records in the sub-process log (0 if none). Served from
+     * the in-memory count maintained by the append path — this does NOT scan
+     * the file. If the count has not been seeded yet (no append since startup
+     * and the file pre-dates this service instance) it falls back to a single
+     * scan, then caches the result for subsequent calls.
      */
     public int getSubProcessLogCount() {
-        File logFile = getSubProcessLogFile();
-        if (logFile == null || !logFile.exists() || logFile.length() == 0) {
-            return 0;
-        }
         synchronized (subProcessLogLock) {
-            try (java.io.BufferedReader reader = new java.io.BufferedReader(
-                    new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
-                int n = 0;
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (!line.trim().isEmpty()) n++;
-                }
-                return n;
+            if (subProcessLogCount >= 0) {
+                return subProcessLogCount;
+            }
+            File logFile = getSubProcessLogFile();
+            if (logFile == null || !logFile.exists() || logFile.length() == 0) {
+                subProcessLogCount = 0;
+                return 0;
+            }
+            try {
+                subProcessLogCount = countSubProcessLogLines(logFile);
             } catch (Exception e) {
                 return 0;
             }
+            return subProcessLogCount;
         }
     }
 

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -254,19 +254,24 @@ public class MonitoringService {
         }
         synchronized (subProcessLogLock) {
             try {
-                // Append first — the hot path must never scan the whole file.
+                // Seed the in-memory count BEFORE appending so that the
+                // subsequent increment reflects the post-append state.
+                // (Seeding after the append would double-count the new line.)
+                if (subProcessLogCount < 0) {
+                    subProcessLogCount = logFile.exists()
+                            ? countSubProcessLogLines(logFile) : 0;
+                }
+
+                // Append — the hot path must never scan the whole file.
                 String line = buildSubProcessRecord(subs, timestamp);
                 try (BufferedWriter writer = new BufferedWriter(
                         new java.io.OutputStreamWriter(new FileOutputStream(logFile, true), StandardCharsets.UTF_8))) {
                     writer.write(line);
                     writer.newLine();
                 }
+                subProcessLogCount++;
 
                 long now = System.currentTimeMillis();
-                if (subProcessLogCount < 0) {
-                    subProcessLogCount = countSubProcessLogLines(logFile);
-                }
-                subProcessLogCount++;
 
                 // Purge only when the line cap is exceeded or the age scan is
                 // due. The age check is a full scan, so it must not run on
@@ -290,7 +295,6 @@ public class MonitoringService {
      * Updates the in-memory line count.
      */
     private void purgeAndCompactSubProcessLog(File logFile, long now) throws IOException {
-        lastSubProcessLogPurgeTime = now;
         if (!logFile.exists() || logFile.length() == 0) {
             subProcessLogCount = 0;
             return;
@@ -324,13 +328,12 @@ public class MonitoringService {
         // Pass 2: rewrite the pruned content to a temp file, then replace the
         // original from it. The temp file is created in the same directory, so
         // the move is a rename on the same filesystem: ATOMIC_MOVE is used when
-        // the platform supports it (the normal case on Linux ext4/xfs), and we
-        // fall back to a NON-ATOMIC replace otherwise — a reader could then
-        // briefly observe either the old or the new content, but never a
-        // truncated file. The in-memory count is published only after the
-        // replacement succeeds; if it fails the file is unchanged, so the count
-        // is left as-is (it still reflects the on-disk lines) and the next
-        // append re-compacts.
+        // the platform supports it (the normal case on Linux ext4/xfs). The
+        // fallback is non-atomic and does not provide the same visibility
+        // guarantees; readers may observe an intermediate state. The in-memory
+        // count and purge time are published only after the replacement
+        // succeeds; if it fails the file is unchanged, so both are left as-is
+        // and the next append re-triggers the purge.
         File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
         try {
             try (BufferedWriter tw = new BufferedWriter(
@@ -347,7 +350,12 @@ public class MonitoringService {
                 // Fallback is a plain (non-atomic) replace.
                 Files.move(tmp.toPath(), logFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
+            // Publish both in-memory state variables only after the
+            // replacement succeeds. If the move fails the file is unchanged,
+            // so the count and purge time are left as-is and the next append
+            // re-triggers the purge.
             subProcessLogCount = newCount;
+            lastSubProcessLogPurgeTime = now;
         } finally {
             // Best-effort delete if the move did not consume the temp file.
             if (tmp.exists()) {
@@ -448,21 +456,23 @@ public class MonitoringService {
             if (eq > 0) {
                 // key=value form: "--password=hunter2" -> "--password=***".
                 String key = t.substring(0, eq);
-                String value = t.substring(eq + 1);
-                if (looksLikeSecretKey(bareKey(key)) && !isBooleanFlagValue(value)) {
+                String bare = bareKey(key);
+                // Strong credentials (password, token, secret, …) are always
+                // redacted — the value may legitimately be "true", "1", etc.
+                // Weak stems (auth, bearer) only redact non-boolean values to
+                // avoid false positives like --authentication-mode=basic.
+                if (isStrongCredential(bare) || (isWeakCredential(bare) && !isBooleanFlagValue(t.substring(eq + 1)))) {
                     toks.set(i, key + "=***");
                     changed = true;
                 }
-            } else if (looksLikeSecretKey(bareKey(t))) {
+            } else if (isStrongCredential(bareKey(t))
+                    || isWeakCredential(bareKey(t))) {
                 // Separate-token form: "--password hunter2" -> "--password ***".
-                // The value is the next token. Skip the two cases where the key
-                // token is not a credential: (a) it carries an "=" value (handled
-                // above), or (b) it is the final token with nothing after it (a
-                // bare flag like "--use-token", not a secret). Otherwise redact
-                // this token and the following one.
-                if (i + 1 < toks.size()) {
-                    toks.set(i, t + " ***");
-                    toks.remove(i + 1);
+                // The value is the next token, but only if it is not itself an
+                // option (does not start with "-"). A bare flag at the end of
+                // the line (--password with no value) is not redacted.
+                if (i + 1 < toks.size() && !toks.get(i + 1).startsWith("-")) {
+                    toks.set(i + 1, "***");
                     i++;
                     changed = true;
                 }
@@ -481,7 +491,11 @@ public class MonitoringService {
         if (value.isEmpty()) return true;
         String v = value.toLowerCase();
         if (v.equals("true") || v.equals("false") || v.equals("yes")
-                || v.equals("no") || v.equals("on") || v.equals("off")) {
+                || v.equals("no") || v.equals("on") || v.equals("off")
+                || v.equals("basic") || v.equals("none") || v.equals("null")
+                || v.equals("disabled") || v.equals("enabled")
+                || v.equals("debug") || v.equals("info") || v.equals("warn")
+                || v.equals("error") || v.equals("verbose")) {
             return true;
         }
         // A bare integer (0, 1, 2, …) is a flag/option, not a credential.
@@ -543,28 +557,34 @@ public class MonitoringService {
         return toks;
     }
 
-    /** True if a command-line argument key looks like a credential. */
-    private static boolean looksLikeSecretKey(String key) {
-        String k = key.toLowerCase();
-        if (k.isEmpty()) {
-            return false;
-        }
-        // Normalize hyphens so "--api-key" matches the "api_key" stem.
-        k = k.replace("-", "_");
-        // Named credential stems only — a long argument name is not evidence of
-        // a secret (the value is what would be long, and we redact the whole
-        // value, so no length heuristic is needed).
-        if (k.contains("password") || k.contains("passwd") || k.contains("pwd")
-                || k.contains("token") || k.contains("secret") || k.contains("apikey")
-                || k.contains("api_key") || k.contains("accesskey") || k.contains("access_key")
+    /**
+     * True if the key is a strong credential: its value is redacted regardless
+     * of content (even if the value looks like a boolean or number). These are
+     * keys that by name are unambiguously secrets — a password, token, or key
+     * whose value is "true" or "1" is still a password.
+     */
+    private static boolean isStrongCredential(String bareKey) {
+        String k = bareKey.toLowerCase().replace("-", "_");
+        if (k.isEmpty()) return false;
+        return k.contains("password") || k.contains("passwd") || k.contains("pwd")
+                || k.contains("token") || k.contains("secret")
+                || k.contains("apikey") || k.contains("api_key")
+                || k.contains("accesskey") || k.contains("access_key")
                 || k.contains("privatekey") || k.contains("private_key")
-                || k.contains("credential") || k.contains("auth") || k.contains("bearer")
-                || k.contains("clientsecret") || k.contains("client_secret")
-                || k.contains("sessiontoken") || k.contains("session_token")
-                || k.contains("refreshtoken") || k.contains("refresh_token")) {
-            return true;
-        }
-        return false;
+                || k.contains("credential") || k.contains("client_secret")
+                || k.contains("session_token") || k.contains("refresh_token");
+    }
+
+    /**
+     * True if the key is a weak credential indicator: the value is redacted
+     * only when it does not look like a boolean flag. These stems appear in
+     * non-credential contexts too (e.g. --authentication-mode, --authorize),
+     * so the boolean guard avoids false positives.
+     */
+    private static boolean isWeakCredential(String bareKey) {
+        String k = bareKey.toLowerCase().replace("-", "_");
+        if (k.isEmpty()) return false;
+        return k.contains("auth") || k.contains("bearer");
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -83,8 +83,10 @@ public class MonitoringService {
     private static final long SUB_PROCESS_LOG_PURGE_INTERVAL = 10L * 60L * 1000L; // 10 min
 
     // In-memory record count for the sub-process log, so the status endpoint
-    // does not need to scan the whole file. Approximate after an external
-    // edit; recomputed exactly on every append.
+    // does not need to scan the whole file. Lazily initialized from the
+    // existing file on first use; thereafter maintained incrementally by the
+    // append path. Approximate after an external edit; recomputed exactly on
+    // every purge/compact.
     private int subProcessLogCount = -1;
     /** Last time the sub-process log was fully scanned for purging. */
     private long lastSubProcessLogPurgeTime = 0;
@@ -317,13 +319,18 @@ public class MonitoringService {
         if (excess > 0) {
             kept.subList(0, excess).clear();
         }
-        subProcessLogCount = kept.size();
+        int newCount = kept.size();
 
-        // Pass 2: rewrite the pruned content to a temp file, then atomically
-        // move it over the original so a reader never sees a partial/truncated
-        // file (the old delete-then-rename left a window where the log was
-        // missing). The move is atomic on the same filesystem; fall back to a
-        // plain rename if the platform doesn't support ATOMIC_MOVE.
+        // Pass 2: rewrite the pruned content to a temp file, then replace the
+        // original from it. The temp file is created in the same directory, so
+        // the move is a rename on the same filesystem: ATOMIC_MOVE is used when
+        // the platform supports it (the normal case on Linux ext4/xfs), and we
+        // fall back to a NON-ATOMIC replace otherwise — a reader could then
+        // briefly observe either the old or the new content, but never a
+        // truncated file. The in-memory count is published only after the
+        // replacement succeeds; if it fails the file is unchanged, so the count
+        // is left as-is (it still reflects the on-disk lines) and the next
+        // append re-compacts.
         File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
         try {
             try (BufferedWriter tw = new BufferedWriter(
@@ -337,8 +344,10 @@ public class MonitoringService {
                 Files.move(tmp.toPath(), logFile.toPath(),
                         StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
             } catch (AtomicMoveNotSupportedException e) {
+                // Fallback is a plain (non-atomic) replace.
                 Files.move(tmp.toPath(), logFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
+            subProcessLogCount = newCount;
         } finally {
             // Best-effort delete if the move did not consume the temp file.
             if (tmp.exists()) {
@@ -403,8 +412,9 @@ public class MonitoringService {
             o.put("slow", sp.slow);
             // The log is persisted (up to 7 days) and readable through the API,
             // so command lines are redacted: an external script can carry
-            // credentials on its command line (--password=..., --token=...),
-            // which must not be written to disk or exposed by the endpoint.
+            // credentials on its command line (--password=..., --token ...,
+            // --api-key ...), which must not be written to disk or exposed by
+            // the endpoint.
             o.put("command", redactCommand(sp.command));
             arr.put(o);
         }
@@ -414,32 +424,123 @@ public class MonitoringService {
 
     /**
      * Redact secret-looking arguments from a command line before it is
-     * persisted to the sub-process log. A token is redacted if its name
-     * (the argument before {@code =}, lowercased) matches a known
-     * credential key, or if the argument is {@code --key=value} where the key
-     * itself looks like a credential. The value is replaced with {@code ***}
-     * while the key is kept, so the record stays useful for analysis.
+     * persisted to the sub-process log. Handles both argument forms:
+     * {@code --password=secret} and the separate-token {@code --password secret}.
+     * The matched value (and the quoted value in {@code --password="secret"} /
+     * {@code --password "secret"}) is replaced with {@code ***} while the key is
+     * kept, so the record stays useful for analysis.
+     *
+     * <p>The line is tokenized quote-aware (so a quoted value with spaces stays
+     * one token); when no token is changed the original string is returned
+     * verbatim. When a redaction happens the tokens are re-joined with single
+     * spaces, which may collapse runs of whitespace in the input — acceptable
+     * for a log, and only on lines that actually carried a secret.
      */
     private static String redactCommand(String command) {
         if (command == null || command.isEmpty()) {
             return command;
         }
-        String[] parts = command.split("\\s+", -1);
+        List<String> toks = tokenizeCommandLine(command);
         boolean changed = false;
-        for (int i = 0; i < parts.length; i++) {
-            String p = parts[i];
-            int eq = p.indexOf('=');
-            if (eq <= 0) {
-                continue;
-            }
-            String key = p.substring(0, eq);
-            String bare = key.startsWith("-") ? key.substring(key.lastIndexOf('-') + 1) : key;
-            if (looksLikeSecretKey(bare)) {
-                parts[i] = key + "=***";
-                changed = true;
+        for (int i = 0; i < toks.size(); i++) {
+            String t = toks.get(i);
+            int eq = t.indexOf('=');
+            if (eq > 0) {
+                // key=value form: "--password=hunter2" -> "--password=***".
+                String key = t.substring(0, eq);
+                String value = t.substring(eq + 1);
+                if (looksLikeSecretKey(bareKey(key)) && !isBooleanFlagValue(value)) {
+                    toks.set(i, key + "=***");
+                    changed = true;
+                }
+            } else if (looksLikeSecretKey(bareKey(t))) {
+                // Separate-token form: "--password hunter2" -> "--password ***".
+                // The value is the next token. Skip the two cases where the key
+                // token is not a credential: (a) it carries an "=" value (handled
+                // above), or (b) it is the final token with nothing after it (a
+                // bare flag like "--use-token", not a secret). Otherwise redact
+                // this token and the following one.
+                if (i + 1 < toks.size()) {
+                    toks.set(i, t + " ***");
+                    toks.remove(i + 1);
+                    i++;
+                    changed = true;
+                }
             }
         }
-        return changed ? String.join(" ", parts) : command;
+        return changed ? String.join(" ", toks) : command;
+    }
+
+    /**
+     * True if the value looks like a boolean flag rather than a credential:
+     * a bare digit, "true", "false", "yes", "no", "on", or "off". Such values
+     * are not secrets even when the key name happens to contain a credential
+     * stem (e.g. {@code --use-token=1}).
+     */
+    private static boolean isBooleanFlagValue(String value) {
+        if (value.isEmpty()) return true;
+        String v = value.toLowerCase();
+        if (v.equals("true") || v.equals("false") || v.equals("yes")
+                || v.equals("no") || v.equals("on") || v.equals("off")) {
+            return true;
+        }
+        // A bare integer (0, 1, 2, …) is a flag/option, not a credential.
+        for (int i = 0; i < v.length(); i++) {
+            if (!Character.isDigit(v.charAt(i))) return false;
+        }
+        return true;
+    }
+
+    /** Strip a leading dash run ("--password" / "-password" -> "password"). */
+    private static String bareKey(String token) {
+        String s = token;
+        while (s.startsWith("-")) {
+            s = s.substring(1);
+        }
+        return s;
+    }
+
+    /**
+     * Tokenize a command line respecting single and double quotes so that a
+     * quoted value with spaces stays one token. Quotes are removed from the
+     * result (matching how the OS passes a single argv element). This is a
+     * deliberate approximation — not a full shell parser — and is only used to
+     * decide which tokens are secrets, not to re-run the command.
+     */
+    private static List<String> tokenizeCommandLine(String command) {
+        List<String> toks = new ArrayList<>();
+        StringBuilder cur = new StringBuilder();
+        boolean inToken = false;
+        int i = 0;
+        int n = command.length();
+        while (i < n) {
+            char c = command.charAt(i);
+            if (Character.isWhitespace(c)) {
+                if (inToken) {
+                    toks.add(cur.toString());
+                    cur.setLength(0);
+                    inToken = false;
+                }
+                i++;
+            } else if (c == '"' || c == '\'') {
+                char quote = c;
+                inToken = true;
+                i++;
+                while (i < n && command.charAt(i) != quote) {
+                    cur.append(command.charAt(i));
+                    i++;
+                }
+                i++; // skip closing quote (or run past the end if unbalanced)
+            } else {
+                cur.append(c);
+                inToken = true;
+                i++;
+            }
+        }
+        if (inToken) {
+            toks.add(cur.toString());
+        }
+        return toks;
     }
 
     /** True if a command-line argument key looks like a credential. */
@@ -448,15 +549,22 @@ public class MonitoringService {
         if (k.isEmpty()) {
             return false;
         }
-        // Common credential key stems.
+        // Normalize hyphens so "--api-key" matches the "api_key" stem.
+        k = k.replace("-", "_");
+        // Named credential stems only — a long argument name is not evidence of
+        // a secret (the value is what would be long, and we redact the whole
+        // value, so no length heuristic is needed).
         if (k.contains("password") || k.contains("passwd") || k.contains("pwd")
                 || k.contains("token") || k.contains("secret") || k.contains("apikey")
                 || k.contains("api_key") || k.contains("accesskey") || k.contains("access_key")
-                || k.contains("privatekey") || k.contains("private_key")) {
+                || k.contains("privatekey") || k.contains("private_key")
+                || k.contains("credential") || k.contains("auth") || k.contains("bearer")
+                || k.contains("clientsecret") || k.contains("client_secret")
+                || k.contains("sessiontoken") || k.contains("session_token")
+                || k.contains("refreshtoken") || k.contains("refresh_token")) {
             return true;
         }
-        // AWS-style keys are 20-char base64; flag anything that long.
-        return k.length() >= 20;
+        return false;
     }
 
     /**
@@ -507,7 +615,8 @@ public class MonitoringService {
      * the in-memory count maintained by the append path — this does NOT scan
      * the file. If the count has not been seeded yet (no append since startup
      * and the file pre-dates this service instance) it falls back to a single
-     * scan, then caches the result for subsequent calls.
+     * scan, then caches the result for subsequent calls. A transient read
+     * failure returns 0 without caching so the next call retries.
      */
     public int getSubProcessLogCount() {
         synchronized (subProcessLogLock) {
@@ -522,6 +631,9 @@ public class MonitoringService {
             try {
                 subProcessLogCount = countSubProcessLogLines(logFile);
             } catch (Exception e) {
+                log.log(Level.WARNING, "Failed to count sub-process log lines " + logFile.getAbsolutePath(), e);
+                // Do NOT cache the failure — leave the count at -1 so the
+                // next call retries (the file may be temporarily locked).
                 return 0;
             }
             return subProcessLogCount;

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -1,8 +1,13 @@
 package biouml.plugins.servermonitor;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -12,6 +17,9 @@ import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import ru.biosoft.tasks.TaskInfo;
 import ru.biosoft.tasks.TaskManager;
@@ -52,6 +60,23 @@ public class MonitoringService {
     private volatile List<SubProcessMonitor.SubProcess> lastSubProcesses = new ArrayList<>();
     private volatile long lastSubProcessCheckTime = 0;
     private volatile boolean firstLoopIteration = true;
+
+    /**
+     * File name (within the profiler directory) used for the persistent
+     * sub-process observation log. Each non-empty scan appends one JSON line,
+     * so the full timeline of long-running external processes is retained even
+     * after they exit — the {@code status} API only shows the live snapshot.
+     */
+    public static final String SUB_PROCESS_LOG_FILE = "subprocesses.jsonl";
+
+    /** Maximum number of JSON lines kept in the sub-process log. */
+    private static final int MAX_SUB_PROCESS_LOG_LINES = 5000;
+    /** Maximum age (ms) of a sub-process log line before it is purged. */
+    private static final long MAX_SUB_PROCESS_LOG_AGE = 7L * 24 * 60 * 60 * 1000; // 7 days
+
+    // Guards append/rewrite of the sub-process log (single monitor thread writes,
+    // but the API can read concurrently; keep the file in a consistent state).
+    private final Object subProcessLogLock = new Object();
 
     public MonitoringService(ServerMonitorConfig config) {
         this.config = config;
@@ -182,9 +207,220 @@ public class MonitoringService {
             List<SubProcessMonitor.SubProcess> subs = subProcessMonitor.check();
             lastSubProcesses = subs;
             lastSubProcessCheckTime = System.currentTimeMillis();
+
+            // Persist every non-empty scan so the timeline of long-running
+            // external processes survives process exit and is retrievable via
+            // the API (the live status only shows the current snapshot).
+            if (!subs.isEmpty()) {
+                appendSubProcessLog(subs, lastSubProcessCheckTime);
+            }
         } catch (Exception e) {
             log.log(Level.WARNING, "Sub-process scan failed", e);
         }
+    }
+
+    /**
+     * Append one JSON line describing a non-empty sub-process scan to the
+     * persistent log. Each line is a self-contained record:
+     * <pre>{"timestamp":..., "checkIntervalSec":..., "subProcesses":[{"pid":..,"ageSeconds":..,"slow":..,"command":..}, ...]}</pre>
+     *
+     * <p>Writing is serialized against {@link #subProcessLogLock}; a rewrite is
+     * performed (under the same lock) when the file exceeds the size/age limits
+     * so the log stays bounded.
+     */
+    private void appendSubProcessLog(List<SubProcessMonitor.SubProcess> subs, long timestamp) {
+        File logFile = getSubProcessLogFile();
+        if (logFile == null) {
+            return;
+        }
+        synchronized (subProcessLogLock) {
+            try {
+                // Purge old / excess lines first (cheap: only read when the
+                // file is already large or the oldest line is past its age).
+                if (logFile.exists() && logFile.length() > 0) {
+                    long now = System.currentTimeMillis();
+                    File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
+                    boolean purged = purgeSubProcessLog(logFile, tmp, now);
+                    if (purged) {
+                        // tmp now holds the pruned content; rename over the original.
+                        if (!logFile.delete() || !tmp.renameTo(logFile)) {
+                            tmp.delete();
+                        }
+                    } else {
+                        tmp.delete();
+                    }
+                }
+
+                String line = buildSubProcessRecord(subs, timestamp);
+                try (BufferedWriter writer = new BufferedWriter(
+                        new java.io.OutputStreamWriter(new FileOutputStream(logFile, true), StandardCharsets.UTF_8))) {
+                    writer.write(line);
+                    writer.newLine();
+                }
+            } catch (Exception e) {
+                log.log(Level.WARNING, "Error appending sub-process log " + logFile.getAbsolutePath(), e);
+            }
+        }
+    }
+
+    /**
+     * Rewrite the sub-process log, dropping lines older than
+     * {@link #MAX_SUB_PROCESS_LOG_AGE} and keeping only the most recent
+     * {@link #MAX_SUB_PROCESS_LOG_LINES}. Returns true if any line was dropped
+     * (i.e. the file content actually changed).
+     */
+    private boolean purgeSubProcessLog(File logFile, File tmp, long now) throws IOException {
+        // Pass 1: read the log, dropping lines older than MAX_SUB_PROCESS_LOG_AGE.
+        List<String> kept = new ArrayList<>();
+        int total = 0;
+        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) continue;
+                total++;
+                long ts = extractTimestamp(line);
+                boolean tooOld = ts > 0 && (now - ts) > MAX_SUB_PROCESS_LOG_AGE;
+                if (!tooOld) {
+                    kept.add(line);
+                }
+            }
+        }
+
+        // Keep only the most recent N lines.
+        int excess = kept.size() - MAX_SUB_PROCESS_LOG_LINES;
+        if (excess > 0) {
+            kept.subList(0, excess).clear();
+        }
+
+        boolean changed = (kept.size() != total);
+        if (changed) {
+            // Pass 2: rewrite the pruned content to tmp (caller renames tmp over logFile).
+            try (BufferedWriter tw = new BufferedWriter(
+                    new java.io.OutputStreamWriter(new FileOutputStream(tmp), StandardCharsets.UTF_8))) {
+                for (String l : kept) {
+                    tw.write(l);
+                    tw.newLine();
+                }
+            }
+        }
+        return changed;
+    }
+
+    /**
+     * Extract the {@code "timestamp":<long>} field from a log line (no full JSON
+     * parse — the field is written first and is always an integer).
+     */
+    private long extractTimestamp(String line) {
+        int idx = line.indexOf("\"timestamp\":");
+        if (idx < 0) return -1;
+        int start = idx + "\"timestamp\":".length();
+        int end = start;
+        while (end < line.length() && (Character.isDigit(line.charAt(end)) || line.charAt(end) == '-')) {
+            end++;
+        }
+        try {
+            return Long.parseLong(line.substring(start, end));
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Build the single JSON line for one sub-process scan.
+     */
+    private String buildSubProcessRecord(List<SubProcessMonitor.SubProcess> subs, long timestamp) {
+        JSONObject record = new JSONObject();
+        record.put("timestamp", timestamp);
+        record.put("checkIntervalSec", config.getCheckInterval());
+        record.put("thresholdSec", config.getSubProcessThreshold());
+        record.put("minAgeSec", config.getSubProcessMinAge());
+        record.put("count", subs.size());
+        JSONArray arr = new JSONArray();
+        for (SubProcessMonitor.SubProcess sp : subs) {
+            JSONObject o = new JSONObject();
+            o.put("pid", sp.pid);
+            o.put("ageSeconds", sp.ageSeconds);
+            o.put("slow", sp.slow);
+            o.put("command", sp.command);
+            arr.put(o);
+        }
+        record.put("subProcesses", arr);
+        return record.toString();
+    }
+
+    /**
+     * Resolve the sub-process log file inside the profiler directory.
+     * Returns null if the directory is not resolvable.
+     */
+    private File getSubProcessLogFile() {
+        try {
+            config.ensureProfilerDir();
+            return new File(config.getProfilerDir(), SUB_PROCESS_LOG_FILE);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Read sub-process log lines whose timestamp falls within [since, until]
+     * (inclusive; either bound may be 0 to mean unbounded). Returns raw JSON
+     * lines (one per scan), most recent last.
+     */
+    public List<String> readSubProcessLog(long since, long until) {
+        List<String> result = new ArrayList<>();
+        File logFile = getSubProcessLogFile();
+        if (logFile == null || !logFile.exists() || logFile.length() == 0) {
+            return result;
+        }
+        synchronized (subProcessLogLock) {
+            try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.trim().isEmpty()) continue;
+                    long ts = extractTimestamp(line);
+                    if (ts < 0) continue;
+                    if (since > 0 && ts < since) continue;
+                    if (until > 0 && ts > until) continue;
+                    result.add(line);
+                }
+            } catch (Exception e) {
+                log.log(Level.WARNING, "Error reading sub-process log " + logFile.getAbsolutePath(), e);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Total number of records in the sub-process log (0 if none).
+     */
+    public int getSubProcessLogCount() {
+        File logFile = getSubProcessLogFile();
+        if (logFile == null || !logFile.exists() || logFile.length() == 0) {
+            return 0;
+        }
+        synchronized (subProcessLogLock) {
+            try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(new FileInputStream(logFile), StandardCharsets.UTF_8))) {
+                int n = 0;
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (!line.trim().isEmpty()) n++;
+                }
+                return n;
+            } catch (Exception e) {
+                return 0;
+            }
+        }
+    }
+
+    /**
+     * Absolute path of the sub-process log file (for API / diagnostics).
+     */
+    public String getSubProcessLogPath() {
+        File f = getSubProcessLogFile();
+        return f != null ? f.getAbsolutePath() : null;
     }
 
     /**
@@ -351,10 +587,17 @@ public class MonitoringService {
         File[] files = profileDir.listFiles();
         if (files == null) return;
 
+        // The sub-process observation log is self-bounding (purged by age/line
+        // count in appendSubProcessLog) — never delete it here.
+        String subProcLogName = SUB_PROCESS_LOG_FILE;
+
         // Age-based cleanup (skip directories like the async-profiler installation)
         for (File f : files) {
             if (f.isDirectory()) {
                 log.fine("Skipping directory during cleanup: " + f.getName());
+                continue;
+            }
+            if (subProcLogName.equals(f.getName())) {
                 continue;
             }
             if (now - f.lastModified() > maxAgeMillis) {
@@ -373,7 +616,7 @@ public class MonitoringService {
             // Filter to only profile files (exclude directories like async-profiler-*)
             List<File> profileFiles = new ArrayList<>();
             for (File f : files) {
-                if (!f.isDirectory()) {
+                if (!f.isDirectory() && !subProcLogName.equals(f.getName())) {
                     profileFiles.add(f);
                 }
             }

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -332,8 +332,8 @@ public class MonitoringService {
         // fallback is non-atomic and does not provide the same visibility
         // guarantees; readers may observe an intermediate state. The in-memory
         // count and purge time are published only after the replacement
-        // succeeds; if it fails the file is unchanged, so both are left as-is
-        // and the next append re-triggers the purge.
+        // succeeds; if the move fails before replacement, the in-memory state
+        // is left unchanged and the next append re-triggers the purge.
         File tmp = File.createTempFile("subproc", ".jsonl", logFile.getParentFile());
         try {
             try (BufferedWriter tw = new BufferedWriter(
@@ -351,8 +351,8 @@ public class MonitoringService {
                 Files.move(tmp.toPath(), logFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
             // Publish both in-memory state variables only after the
-            // replacement succeeds. If the move fails the file is unchanged,
-            // so the count and purge time are left as-is and the next append
+            // replacement succeeds. If the move fails before replacement,
+            // the in-memory state is left unchanged and the next append
             // re-triggers the purge.
             subProcessLogCount = newCount;
             lastSubProcessLogPurgeTime = now;
@@ -482,20 +482,16 @@ public class MonitoringService {
     }
 
     /**
-     * True if the value looks like a boolean flag rather than a credential:
-     * a bare digit, "true", "false", "yes", "no", "on", or "off". Such values
-     * are not secrets even when the key name happens to contain a credential
-     * stem (e.g. {@code --use-token=1}).
+     * True if the value is a literal boolean or a bare integer — the kinds of
+     * values that appear on non-credential flags (e.g. {@code --enable-foo=1}).
+     * Used only for weak credential stems to avoid redacting
+     * {@code --authentication-mode=basic} or {@code --authorize=true}.
      */
     private static boolean isBooleanFlagValue(String value) {
         if (value.isEmpty()) return true;
         String v = value.toLowerCase();
         if (v.equals("true") || v.equals("false") || v.equals("yes")
-                || v.equals("no") || v.equals("on") || v.equals("off")
-                || v.equals("basic") || v.equals("none") || v.equals("null")
-                || v.equals("disabled") || v.equals("enabled")
-                || v.equals("debug") || v.equals("info") || v.equals("warn")
-                || v.equals("error") || v.equals("verbose")) {
+                || v.equals("no") || v.equals("on") || v.equals("off")) {
             return true;
         }
         // A bare integer (0, 1, 2, …) is a flag/option, not a credential.
@@ -517,9 +513,14 @@ public class MonitoringService {
     /**
      * Tokenize a command line respecting single and double quotes so that a
      * quoted value with spaces stays one token. Quotes are removed from the
-     * result (matching how the OS passes a single argv element). This is a
-     * deliberate approximation — not a full shell parser — and is only used to
-     * decide which tokens are secrets, not to re-run the command.
+     * result (matching how the OS passes a single argv element).
+     *
+     * <p>This is a deliberate approximation — not a full shell parser — and is
+     * only used to decide which tokens are secrets, not to re-run the command.
+     * In particular, it does not handle backslash escapes inside quoted strings
+     * ({@code --password="abc\"def"} will be split at the inner {@code "}), so
+     * a credential in an escaped-quote command line may not be recognized and
+     * will not be redacted.
      */
     private static List<String> tokenizeCommandLine(String command) {
         List<String> toks = new ArrayList<>();
@@ -558,33 +559,70 @@ public class MonitoringService {
     }
 
     /**
+     * Split a bare key into lowercase components on {@code -}, {@code _},
+     * and camelCase boundaries. {@code api-key} → {@code [api, key]},
+     * {@code apiToken} → {@code [api, token]}, {@code client_secret}
+     * → {@code [client, secret]}.
+     */
+    private static java.util.Set<String> splitKey(String bareKey) {
+        // Insert a separator at camelCase boundaries: "apiToken" → "api Token"
+        String s = bareKey.replaceAll("([a-z0-9])([A-Z])", "$1 $2");
+        String k = s.toLowerCase();
+        String[] parts = k.split("[-_\\s]+");
+        java.util.Set<String> set = new java.util.HashSet<>();
+        for (String p : parts) {
+            if (!p.isEmpty()) set.add(p);
+        }
+        return set;
+    }
+
+    /**
      * True if the key is a strong credential: its value is redacted regardless
-     * of content (even if the value looks like a boolean or number). These are
-     * keys that by name are unambiguously secrets — a password, token, or key
-     * whose value is "true" or "1" is still a password.
+     * of content (even if the value looks like a boolean or number). Matching
+     * is component-based — {@code --token-count=10} has components
+     * {@code [token, count]} and the "count" component means it is NOT a
+     * credential, while {@code --auth-token=abc} has components
+     * {@code [auth, token]} and IS a credential.
      */
     private static boolean isStrongCredential(String bareKey) {
-        String k = bareKey.toLowerCase().replace("-", "_");
-        if (k.isEmpty()) return false;
-        return k.contains("password") || k.contains("passwd") || k.contains("pwd")
-                || k.contains("token") || k.contains("secret")
-                || k.contains("apikey") || k.contains("api_key")
-                || k.contains("accesskey") || k.contains("access_key")
-                || k.contains("privatekey") || k.contains("private_key")
-                || k.contains("credential") || k.contains("client_secret")
-                || k.contains("session_token") || k.contains("refresh_token");
+        if (bareKey.isEmpty()) return false;
+        java.util.Set<String> parts = splitKey(bareKey);
+        if (parts.isEmpty()) return false;
+        // Single-component keys: the whole key is a credential word.
+        // ("--password", "--token", "--secret", "--credential")
+        if (parts.size() == 1) {
+            String p = parts.iterator().next();
+            return p.equals("password") || p.equals("passwd") || p.equals("pwd")
+                    || p.equals("token") || p.equals("secret")
+                    || p.equals("credential");
+        }
+        // Multi-component keys: match known credential compound names.
+        // ("--api-key", "--access-key", "--client-secret", "--auth-token",
+        //  "--session-token", "--refresh-token", "--private-key")
+        if (parts.contains("api") && parts.contains("key")) return true;
+        if (parts.contains("access") && parts.contains("key")) return true;
+        if (parts.contains("private") && parts.contains("key")) return true;
+        if (parts.contains("client") && parts.contains("secret")) return true;
+        if (parts.contains("session") && parts.contains("token")) return true;
+        if (parts.contains("refresh") && parts.contains("token")) return true;
+        // "auth-token", "password-hash", etc. — a credential word combined
+        // with a qualifier is still a credential. But "token-count" and
+        // "secret-mode" are not: the qualifier changes the meaning.
+        if (parts.contains("auth") && parts.contains("token")) return true;
+        return false;
     }
 
     /**
      * True if the key is a weak credential indicator: the value is redacted
-     * only when it does not look like a boolean flag. These stems appear in
-     * non-credential contexts too (e.g. --authentication-mode, --authorize),
-     * so the boolean guard avoids false positives.
+     * only when it does not look like a boolean flag. Component-based:
+     * {@code --auth} or {@code --bearer} is a weak credential, but
+     * {@code --authentication-mode} is not (the component is
+     * "authentication", not "auth").
      */
     private static boolean isWeakCredential(String bareKey) {
-        String k = bareKey.toLowerCase().replace("-", "_");
-        if (k.isEmpty()) return false;
-        return k.contains("auth") || k.contains("bearer");
+        if (bareKey.isEmpty()) return false;
+        java.util.Set<String> parts = splitKey(bareKey);
+        return parts.contains("auth") || parts.contains("bearer");
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/MonitoringService.java
+++ b/src/biouml/plugins/servermonitor/MonitoringService.java
@@ -559,70 +559,86 @@ public class MonitoringService {
     }
 
     /**
-     * Split a bare key into lowercase components on {@code -}, {@code _},
-     * and camelCase boundaries. {@code api-key} → {@code [api, key]},
-     * {@code apiToken} → {@code [api, token]}, {@code client_secret}
-     * → {@code [client, secret]}.
+     * Split a bare key into an ordered list of lowercase components on
+     * {@code -}, {@code _}, and camelCase boundaries.
+     * {@code api-key} → {@code [api, key]}, {@code apiToken} →
+     * {@code [api, token]}, {@code APIKey} → {@code [api, key]},
+     * {@code client_secret} → {@code [client, secret]}.
+     *
+     * <p>Handles both the lower→upper boundary ({@code apiToken}) and the
+     * acronym→PascalCase boundary ({@code APIKey} → {@code API Key}).
      */
-    private static java.util.Set<String> splitKey(String bareKey) {
-        // Insert a separator at camelCase boundaries: "apiToken" → "api Token"
+    private static List<String> splitKey(String bareKey) {
+        // Insert a space at camelCase boundaries:
+        //   "apiToken" → "api Token"   (lower→upper)
+        //   "APIKey"   → "API Key"     (acronym→PascalCase)
         String s = bareKey.replaceAll("([a-z0-9])([A-Z])", "$1 $2");
+        s = s.replaceAll("([A-Z])([A-Z][a-z])", "$1 $2");
         String k = s.toLowerCase();
-        String[] parts = k.split("[-_\\s]+");
-        java.util.Set<String> set = new java.util.HashSet<>();
-        for (String p : parts) {
-            if (!p.isEmpty()) set.add(p);
+        List<String> parts = new ArrayList<>();
+        for (String p : k.split("[-_\\s]+")) {
+            if (!p.isEmpty()) parts.add(p);
         }
-        return set;
+        return parts;
+    }
+
+    /**
+     * True if the ordered component list exactly matches the given sequence.
+     */
+    private static boolean isExactCompound(List<String> parts, String... expected) {
+        if (parts.size() != expected.length) return false;
+        for (int i = 0; i < expected.length; i++) {
+            if (!parts.get(i).equals(expected[i])) return false;
+        }
+        return true;
     }
 
     /**
      * True if the key is a strong credential: its value is redacted regardless
      * of content (even if the value looks like a boolean or number). Matching
-     * is component-based — {@code --token-count=10} has components
-     * {@code [token, count]} and the "count" component means it is NOT a
-     * credential, while {@code --auth-token=abc} has components
-     * {@code [auth, token]} and IS a credential.
+     * is by exact component sequence — {@code --api-key} matches
+     * {@code [api, key]} but {@code --api-key-mode} ({@code [api, key, mode]})
+     * and {@code --key-api} ({@code [key, api]}) do not.
+     *
+     * <p>Recognized strong credentials:
+     * <ul>
+     *   <li>Single component: password, passwd, pwd, token, secret, credential</li>
+     *   <li>Two-component: api-key, access-key, private-key, client-secret,
+     *       session-token, refresh-token, auth-token, bearer-token</li>
+     * </ul>
      */
     private static boolean isStrongCredential(String bareKey) {
         if (bareKey.isEmpty()) return false;
-        java.util.Set<String> parts = splitKey(bareKey);
+        List<String> parts = splitKey(bareKey);
         if (parts.isEmpty()) return false;
-        // Single-component keys: the whole key is a credential word.
-        // ("--password", "--token", "--secret", "--credential")
         if (parts.size() == 1) {
-            String p = parts.iterator().next();
+            String p = parts.get(0);
             return p.equals("password") || p.equals("passwd") || p.equals("pwd")
                     || p.equals("token") || p.equals("secret")
                     || p.equals("credential");
         }
-        // Multi-component keys: match known credential compound names.
-        // ("--api-key", "--access-key", "--client-secret", "--auth-token",
-        //  "--session-token", "--refresh-token", "--private-key")
-        if (parts.contains("api") && parts.contains("key")) return true;
-        if (parts.contains("access") && parts.contains("key")) return true;
-        if (parts.contains("private") && parts.contains("key")) return true;
-        if (parts.contains("client") && parts.contains("secret")) return true;
-        if (parts.contains("session") && parts.contains("token")) return true;
-        if (parts.contains("refresh") && parts.contains("token")) return true;
-        // "auth-token", "password-hash", etc. — a credential word combined
-        // with a qualifier is still a credential. But "token-count" and
-        // "secret-mode" are not: the qualifier changes the meaning.
-        if (parts.contains("auth") && parts.contains("token")) return true;
-        return false;
+        return isExactCompound(parts, "api", "key")
+                || isExactCompound(parts, "access", "key")
+                || isExactCompound(parts, "private", "key")
+                || isExactCompound(parts, "client", "secret")
+                || isExactCompound(parts, "session", "token")
+                || isExactCompound(parts, "refresh", "token")
+                || isExactCompound(parts, "auth", "token")
+                || isExactCompound(parts, "bearer", "token");
     }
 
     /**
      * True if the key is a weak credential indicator: the value is redacted
-     * only when it does not look like a boolean flag. Component-based:
-     * {@code --auth} or {@code --bearer} is a weak credential, but
-     * {@code --authentication-mode} is not (the component is
+     * only when it does not look like a boolean flag. Matching is by exact
+     * single-component — {@code --auth} or {@code --bearer} is a weak
+     * credential, but {@code --authentication-mode} is not (the component is
      * "authentication", not "auth").
      */
     private static boolean isWeakCredential(String bareKey) {
         if (bareKey.isEmpty()) return false;
-        java.util.Set<String> parts = splitKey(bareKey);
-        return parts.contains("auth") || parts.contains("bearer");
+        List<String> parts = splitKey(bareKey);
+        return parts.size() == 1
+                && (parts.get(0).equals("auth") || parts.get(0).equals("bearer"));
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/README.md
+++ b/src/biouml/plugins/servermonitor/README.md
@@ -79,15 +79,25 @@ history, so a slow external process can be inspected long after it exits.
 
 Each record is one scan:
 ```json
-{"timestamp":…,"checkIntervalSec":…,"thresholdSec":…,"minAgeSec":…,"count":…,
+{"version":1,"timestamp":…,"checkIntervalSec":…,"thresholdSec":…,"minAgeSec":…,"count":…,
  "subProcesses":[{"pid":…,"ageSeconds":…,"slow":…,"command":"perl script.pl --opt1"}, …]}
 ```
 
 - `slowOnly=true` — keep only scans that contained an over-threshold process.
-- `since` / `until` — filter by record timestamp (epoch millis, inclusive).
-- The `status` endpoint also reports `subProcessLogPath` and `subProcessLogCount`.
+- `since` / `until` — filter by record timestamp (epoch millis, inclusive). Both
+  must be `>= 0` and `until >= since`, otherwise the endpoint returns an error.
+- The `status` endpoint also reports `subProcessLogPath` and `subProcessLogCount`
+  (served from an in-memory count, not a file scan).
+- **Command-line redaction** — because the log is persisted (up to 7 days) and
+  readable through this endpoint, command lines are redacted before writing: any
+  `--key=value` argument whose key looks like a credential (password, token,
+  secret, api/access key, etc.) has its value replaced with `***`. This prevents
+  credentials passed on an external script's command line from leaking into the
+  log.
 - The log is self-bounding (7-day age cap, 5000-line cap) and is excluded from
-  profile cleanup.
+  profile cleanup. Purging (a full scan) runs only when the line cap is
+  exceeded or at most every 10 minutes — the hot append path never rewrites the
+  file, and rewrites are applied atomically (temp file + atomic move).
 
 ### Stop profiling
 

--- a/src/biouml/plugins/servermonitor/README.md
+++ b/src/biouml/plugins/servermonitor/README.md
@@ -99,7 +99,8 @@ Each record is one scan:
   periodic compaction (at most every 10 minutes), and the file is capped at
   5000 lines. It is excluded from profile cleanup. The hot append path never
   rewrites the file; purges use a temp file + atomic move (falling back to a
-  non-atomic replace if the filesystem does not support `ATOMIC_MOVE`).
+  non-atomic replace if the filesystem does not support `ATOMIC_MOVE`, in
+  which case readers may briefly observe an intermediate state).
 
 ### Stop profiling
 

--- a/src/biouml/plugins/servermonitor/README.md
+++ b/src/biouml/plugins/servermonitor/README.md
@@ -88,16 +88,18 @@ Each record is one scan:
   must be `>= 0` and `until >= since`, otherwise the endpoint returns an error.
 - The `status` endpoint also reports `subProcessLogPath` and `subProcessLogCount`
   (served from an in-memory count, not a file scan).
-- **Command-line redaction** — because the log is persisted (up to 7 days) and
-  readable through this endpoint, command lines are redacted before writing: any
-  `--key=value` argument whose key looks like a credential (password, token,
-  secret, api/access key, etc.) has its value replaced with `***`. This prevents
-  credentials passed on an external script's command line from leaking into the
-  log.
-- The log is self-bounding (7-day age cap, 5000-line cap) and is excluded from
-  profile cleanup. Purging (a full scan) runs only when the line cap is
-  exceeded or at most every 10 minutes — the hot append path never rewrites the
-  file, and rewrites are applied atomically (temp file + atomic move).
+- **Command-line redaction** — because the log is persisted and readable
+  through this endpoint, command lines are redacted before writing: any argument
+  whose key looks like a credential (password, token, secret, api/access key,
+  auth, bearer, client/session/refresh token, etc.) has its value replaced with
+  `***`. Both `--key=value` and the separate-token `--key value` forms are
+  handled, including quoted values. This prevents credentials passed on an
+  external script's command line from leaking into the log.
+- The log is self-bounding: records older than 7 days are removed during
+  periodic compaction (at most every 10 minutes), and the file is capped at
+  5000 lines. It is excluded from profile cleanup. The hot append path never
+  rewrites the file; purges use a temp file + atomic move (falling back to a
+  non-atomic replace if the filesystem does not support `ATOMIC_MOVE`).
 
 ### Stop profiling
 

--- a/src/biouml/plugins/servermonitor/README.md
+++ b/src/biouml/plugins/servermonitor/README.md
@@ -57,9 +57,37 @@ Returns a text-based profile summary optimized for AI agent consumption. The res
 - Collapsed stacks (primary output, top 100 call chains by sample count, sorted)
 - Tree profile (hierarchical call chains with CPU time)
 - Traces (secondary format, top 50 call chains)
+- Slow sub-processes observed during the profile's time window (see below)
 - Instructions for AI agents on how to analyze the profile
 
 This format is designed to be easily parsed by AI agents to suggest code changes.
+
+### Sub-process log (external scripts)
+
+```
+GET /biouml/support/profile?action=subProcessLog
+GET /biouml/support/profile?action=subProcessLog&slowOnly=true
+GET /biouml/support/profile?action=subProcessLog&since=<epochMillis>&until=<epochMillis>
+```
+
+async-profiler only samples the JVM, so a task whose time is spent in an
+external script (perl / R / nextflow / git) produces a near-empty CPU profile.
+The `SubProcessMonitor` walks the OS process tree under the JVM on every check
+cycle and **persists every non-empty scan** to a JSON-lines log
+(`subprocesses.jsonl` in the profiler directory). This endpoint returns that
+history, so a slow external process can be inspected long after it exits.
+
+Each record is one scan:
+```json
+{"timestamp":…,"checkIntervalSec":…,"thresholdSec":…,"minAgeSec":…,"count":…,
+ "subProcesses":[{"pid":…,"ageSeconds":…,"slow":…,"command":"perl script.pl --opt1"}, …]}
+```
+
+- `slowOnly=true` — keep only scans that contained an over-threshold process.
+- `since` / `until` — filter by record timestamp (epoch millis, inclusive).
+- The `status` endpoint also reports `subProcessLogPath` and `subProcessLogCount`.
+- The log is self-bounding (7-day age cap, 5000-line cap) and is excluded from
+  profile cleanup.
 
 ### Stop profiling
 

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -38,8 +38,10 @@ public class TestSubProcessLog extends junit.framework.TestCase
         TestSuite suite = new TestSuite(TestSubProcessLog.class.getName());
         suite.addTest(new TestSubProcessLog("testAppendAndRead"));
         suite.addTest(new TestSubProcessLog("testReadSinceUntil"));
-        suite.addTest(new TestSubProcessLog("testPurgeByAgeAndCount"));
+        suite.addTest(new TestSubProcessLog("testPurgeByAge"));
+        suite.addTest(new TestSubProcessLog("testPurgeByCountOverCap"));
         suite.addTest(new TestSubProcessLog("testExtractTimestamp"));
+        suite.addTest(new TestSubProcessLog("testRedactCommand"));
         return suite;
     }
 
@@ -106,12 +108,20 @@ public class TestSubProcessLog extends junit.framework.TestCase
         return (Long) m.invoke(service, line);
     }
 
-    /** Call private purgeSubProcessLog(File, File, long). */
-    private boolean purge(File logFile, File tmp, long now) throws Exception
+    /** Call private purgeAndCompactSubProcessLog(File, long) (does the atomic rename itself). */
+    private void purgeAndCompact(File logFile, long now) throws Exception
     {
-        Method m = MonitoringService.class.getDeclaredMethod("purgeSubProcessLog", File.class, File.class, long.class);
+        Method m = MonitoringService.class.getDeclaredMethod("purgeAndCompactSubProcessLog", File.class, long.class);
         m.setAccessible(true);
-        return (Boolean) m.invoke(service, logFile, tmp, now);
+        m.invoke(service, logFile, now);
+    }
+
+    /** Call private static redactCommand(String). */
+    private String redactCommand(String command) throws Exception
+    {
+        Method m = MonitoringService.class.getDeclaredMethod("redactCommand", String.class);
+        m.setAccessible(true);
+        return (String) m.invoke(null, command);
     }
 
     // ---------- tests ----------
@@ -169,33 +179,53 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(0, service.readSubProcessLog(base + 200_000L, 0).size());
     }
 
-    public void testPurgeByAgeAndCount() throws Exception
+    public void testPurgeByAge() throws Exception
     {
         File logFile = new File(tmpDir, MonitoringService.SUB_PROCESS_LOG_FILE);
-        File tmp = new File(tmpDir, "tmp.jsonl");
 
         // Write 5 lines: 2 old (past 7-day age), 3 recent.
         long now = 5_000_000_000L;
         long weekMs = 7L * 24 * 60 * 60 * 1000;
         String old = "{\"timestamp\":" + (now - weekMs - 1000) + ",\"subProcesses\":[]}";
         String recent = "{\"timestamp\":" + (now - 1000) + ",\"subProcesses\":[]}";
-        try (OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(logFile), StandardCharsets.UTF_8))
-        {
-            for (int i = 0; i < 5; i++)
-            {
-                w.write(i < 2 ? old : recent);
-                w.write("\n");
-            }
-        }
+        writeLines(logFile, old, old, recent, recent, recent);
 
-        boolean changed = purge(logFile, tmp, now);
-        assertTrue("purge should drop the 2 old lines", changed);
+        purgeAndCompact(logFile, now);
 
-        // After rename, 3 recent lines remain.
-        assertTrue(logFile.delete());
-        assertTrue(tmp.renameTo(logFile));
+        // Atomic replacement done; 3 recent lines remain and the count matches.
         List<String> remaining = service.readSubProcessLog(0, 0);
         assertEquals(3, remaining.size());
+        assertEquals(3, service.getSubProcessLogCount());
+    }
+
+    public void testPurgeByCountOverCap() throws Exception
+    {
+        File logFile = new File(tmpDir, MonitoringService.SUB_PROCESS_LOG_FILE);
+
+        // 5002 recent lines (within the 7-day age window, so only the line-cap
+        // should trim). The cap keeps the most recent 5000, dropping the 2 oldest.
+        int n = 5002;
+        long now = 5_000_000_000L;
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++)
+        {
+            sb.append("{\"timestamp\":").append(now - (n - i) * 1000L)
+              .append(",\"subProcesses\":[]}").append("\n");
+        }
+        try (OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(logFile), StandardCharsets.UTF_8))
+        {
+            w.write(sb.toString());
+        }
+
+        purgeAndCompact(logFile, now);
+
+        List<String> remaining = service.readSubProcessLog(0, 0);
+        assertEquals("cap keeps exactly 5000 lines", 5000, remaining.size());
+        assertEquals(5000, service.getSubProcessLogCount());
+        // The two oldest records were dropped: the earliest surviving timestamp
+        // is the 3rd one written.
+        long earliest = new org.json.JSONObject(remaining.get(0)).getLong("timestamp");
+        assertEquals(now - (n - 2) * 1000L, earliest);
     }
 
     public void testExtractTimestamp() throws Exception
@@ -204,5 +234,36 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(1234567890L, extractTimestamp("  garbage {\"timestamp\":1234567890} trailing"));
         assertEquals(-1, extractTimestamp("{\"count\":1}"));
         assertEquals(-1, extractTimestamp("no timestamp here"));
+    }
+
+    public void testRedactCommand() throws Exception
+    {
+        // Secret-looking arguments are masked, non-secrets kept.
+        assertEquals(
+                "perl run.pl --host=db1 --password=*** --input=in.csv",
+                redactCommand("perl run.pl --host=db1 --password=hunter2 --input=in.csv"));
+        assertEquals(
+                "python fetch.py --token=*** --retry=3",
+                redactCommand("python fetch.py --token=abc123 --retry=3"));
+        // No secret -> unchanged (exact string, not re-joined).
+        assertEquals(
+                "perl run.pl --host=db1 --input=in.csv",
+                redactCommand("perl run.pl --host=db1 --input=in.csv"));
+        // Null / empty pass through.
+        assertNull(redactCommand(null));
+        assertEquals("", redactCommand(""));
+    }
+
+    /** Write a fixed set of lines to the log file (one per line). */
+    private static void writeLines(File logFile, String... lines) throws Exception
+    {
+        try (OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(logFile), StandardCharsets.UTF_8))
+        {
+            for (String l : lines)
+            {
+                w.write(l);
+                w.write("\n");
+            }
+        }
     }
 }

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -40,6 +40,7 @@ public class TestSubProcessLog extends junit.framework.TestCase
         suite.addTest(new TestSubProcessLog("testReadSinceUntil"));
         suite.addTest(new TestSubProcessLog("testPurgeByAge"));
         suite.addTest(new TestSubProcessLog("testPurgeByCountOverCap"));
+        suite.addTest(new TestSubProcessLog("testPurgeDropsMalformedLines"));
         suite.addTest(new TestSubProcessLog("testExtractTimestamp"));
         suite.addTest(new TestSubProcessLog("testRedactCommand"));
         return suite;
@@ -228,6 +229,26 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(now - (n - 2) * 1000L, earliest);
     }
 
+    public void testPurgeDropsMalformedLines() throws Exception
+    {
+        File logFile = new File(tmpDir, MonitoringService.SUB_PROCESS_LOG_FILE);
+
+        // Mix valid and malformed lines (no parseable timestamp). The malformed
+        // lines must be dropped on compact, not retained forever.
+        long now = 5_000_000_000L;
+        String valid = "{\"timestamp\":" + (now - 1000) + ",\"subProcesses\":[]}";
+        String noTs = "{\"count\":1}";
+        String garbage = "this is not even json";
+        String blank = "";
+        writeLines(logFile, valid, noTs, valid, garbage, blank, valid);
+
+        purgeAndCompact(logFile, now);
+
+        List<String> remaining = service.readSubProcessLog(0, 0);
+        assertEquals("only the 3 valid lines survive", 3, remaining.size());
+        assertEquals(3, service.getSubProcessLogCount());
+    }
+
     public void testExtractTimestamp() throws Exception
     {
         assertEquals(1234567890L, extractTimestamp("{\"timestamp\":1234567890,\"count\":1}"));
@@ -238,13 +259,54 @@ public class TestSubProcessLog extends junit.framework.TestCase
 
     public void testRedactCommand() throws Exception
     {
-        // Secret-looking arguments are masked, non-secrets kept.
+        // --- key=value form ---
         assertEquals(
                 "perl run.pl --host=db1 --password=*** --input=in.csv",
                 redactCommand("perl run.pl --host=db1 --password=hunter2 --input=in.csv"));
         assertEquals(
                 "python fetch.py --token=*** --retry=3",
                 redactCommand("python fetch.py --token=abc123 --retry=3"));
+
+        // --- separate-token form (--secret value) ---
+        assertEquals(
+                "perl run.pl --host=db1 --password *** --input=in.csv",
+                redactCommand("perl run.pl --host=db1 --password hunter2 --input=in.csv"));
+        assertEquals(
+                "python fetch.py --token *** --retry=3",
+                redactCommand("python fetch.py --token abc123 --retry=3"));
+
+        // --- quoted forms (tokenizer strips quotes, so re-joined output has none) ---
+        assertEquals(
+                "perl run.pl --password=*** --input=in.csv",
+                redactCommand("perl run.pl --password=\"hunter2\" --input=in.csv"));
+        assertEquals(
+                "perl run.pl --password *** --input=in.csv",
+                redactCommand("perl run.pl --password \"hunter 2\" --input=in.csv"));
+
+        // --- non-secret keys are NOT redacted (no length heuristic) ---
+        assertEquals(
+                "perl run.pl --very_long_parameter_name=value --input=in.csv",
+                redactCommand("perl run.pl --very_long_parameter_name=value --input=in.csv"));
+        assertEquals(
+                "perl run.pl --use-token=1",
+                redactCommand("perl run.pl --use-token=1"));
+
+        // --- bare flag at end of line (no value) is not redacted ---
+        assertEquals(
+                "perl run.pl --password",
+                redactCommand("perl run.pl --password"));
+
+        // --- api-key / client_secret / auth variants ---
+        assertEquals(
+                "curl --api-key=*** -u user",
+                redactCommand("curl --api-key=secret123 -u user"));
+        assertEquals(
+                "app --client-secret *** --verbose",
+                redactCommand("app --client-secret topsecret --verbose"));
+        assertEquals(
+                "app --auth-token=*** --verbose",
+                redactCommand("app --auth-token=abc --verbose"));
+
         // No secret -> unchanged (exact string, not re-joined).
         assertEquals(
                 "perl run.pl --host=db1 --input=in.csv",

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -414,6 +414,11 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(
                 "app --token ***",
                 redactCommand("app --token 1"));
+        // Compound strong credential in separate-token form: the key is
+        // matched (strong), so the value is redacted regardless of appearance.
+        assertEquals(
+                "app --client-secret ***",
+                redactCommand("app --client-secret true"));
 
         // --- bare flag at end of line (no value) is not redacted ---
         assertEquals(

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -1,0 +1,208 @@
+package biouml.plugins.servermonitor._test;
+
+import biouml.plugins.servermonitor.MonitoringService;
+import biouml.plugins.servermonitor.ServerMonitorConfig;
+import biouml.plugins.servermonitor.SubProcessMonitor;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Tests the persistent sub-process observation log in {@link MonitoringService}:
+ * appending records, reading them back (with time-range filtering), counting,
+ * and purging old / excess lines.
+ *
+ * <p>Constructs a real {@link MonitoringService} but never calls {@code start()},
+ * so no monitor thread is spawned and no profiler is touched. The private log
+ * methods are exercised via reflection.
+ */
+public class TestSubProcessLog extends junit.framework.TestCase
+{
+    private MonitoringService service;
+    private File tmpDir;
+
+    public TestSubProcessLog(String name)
+    {
+        super(name);
+    }
+
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite(TestSubProcessLog.class.getName());
+        suite.addTest(new TestSubProcessLog("testAppendAndRead"));
+        suite.addTest(new TestSubProcessLog("testReadSinceUntil"));
+        suite.addTest(new TestSubProcessLog("testPurgeByAgeAndCount"));
+        suite.addTest(new TestSubProcessLog("testExtractTimestamp"));
+        return suite;
+    }
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        super.setUp();
+        tmpDir = createTempDir();
+        ServerMonitorConfig config = new ServerMonitorConfig();
+        config.set(ServerMonitorConfig.PROFILER_DIR, tmpDir.getAbsolutePath());
+        // A fresh service with no monitor thread (start() is never called).
+        service = new MonitoringService(config);
+    }
+
+    @Override
+    protected void tearDown() throws Exception
+    {
+        deleteRecursively(tmpDir);
+        super.tearDown();
+    }
+
+    // ---------- helpers ----------
+
+    private static File createTempDir() throws Exception
+    {
+        File dir = File.createTempFile("subproclog", "");
+        dir.delete();
+        dir.mkdirs();
+        return dir;
+    }
+
+    private static void deleteRecursively(File f)
+    {
+        if (f == null || !f.exists()) return;
+        File[] children = f.listFiles();
+        if (children != null)
+            for (File c : children)
+                deleteRecursively(c);
+        f.delete();
+    }
+
+    /** Build one SubProcess via its package-private constructor. */
+    private SubProcessMonitor.SubProcess makeSub(long pid, long age, boolean slow, String cmd) throws Exception
+    {
+        java.lang.reflect.Constructor<SubProcessMonitor.SubProcess> ctor =
+                SubProcessMonitor.SubProcess.class.getDeclaredConstructor(long.class, long.class, String.class, boolean.class);
+        ctor.setAccessible(true);
+        return ctor.newInstance(pid, age, cmd, slow);
+    }
+
+    /** Call private appendSubProcessLog(List, long). */
+    private void append(List<SubProcessMonitor.SubProcess> subs, long ts) throws Exception
+    {
+        Method m = MonitoringService.class.getDeclaredMethod("appendSubProcessLog", List.class, long.class);
+        m.setAccessible(true);
+        m.invoke(service, subs, ts);
+    }
+
+    /** Call private extractTimestamp(String). */
+    private long extractTimestamp(String line) throws Exception
+    {
+        Method m = MonitoringService.class.getDeclaredMethod("extractTimestamp", String.class);
+        m.setAccessible(true);
+        return (Long) m.invoke(service, line);
+    }
+
+    /** Call private purgeSubProcessLog(File, File, long). */
+    private boolean purge(File logFile, File tmp, long now) throws Exception
+    {
+        Method m = MonitoringService.class.getDeclaredMethod("purgeSubProcessLog", File.class, File.class, long.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(service, logFile, tmp, now);
+    }
+
+    // ---------- tests ----------
+
+    public void testAppendAndRead() throws Exception
+    {
+        // Use realistic (wall-clock) timestamps so the age-based purge in
+        // appendSubProcessLog does not treat them as ancient.
+        long base = System.currentTimeMillis();
+
+        java.util.ArrayList<SubProcessMonitor.SubProcess> subs = new java.util.ArrayList<>();
+        subs.add(makeSub(111, 340, true, "perl script.pl --opt1"));
+        subs.add(makeSub(222, 90, false, "Rscript analysis.R"));
+
+        long t1 = base;
+        append(subs, t1);
+
+        // Second scan, one process gone, one still alive.
+        java.util.ArrayList<SubProcessMonitor.SubProcess> subs2 = new java.util.ArrayList<>();
+        subs2.add(makeSub(222, 150, false, "Rscript analysis.R"));
+        long t2 = t1 + 60_000L;
+        append(subs2, t2);
+
+        assertEquals("two records", 2, service.getSubProcessLogCount());
+        List<String> lines = service.readSubProcessLog(0, 0);
+        assertEquals(2, lines.size());
+
+        // First record round-trips pid/command correctly.
+        org.json.JSONObject rec1 = new org.json.JSONObject(lines.get(0));
+        assertEquals(t1, rec1.getLong("timestamp"));
+        assertEquals(2, rec1.getInt("count"));
+        org.json.JSONArray arr = rec1.getJSONArray("subProcesses");
+        assertEquals(111, arr.getJSONObject(0).getLong("pid"));
+        assertEquals(true, arr.getJSONObject(0).getBoolean("slow"));
+        assertEquals("perl script.pl --opt1", arr.getJSONObject(0).getString("command"));
+    }
+
+    public void testReadSinceUntil() throws Exception
+    {
+        long base = System.currentTimeMillis();
+        java.util.ArrayList<SubProcessMonitor.SubProcess> subs = new java.util.ArrayList<>();
+        subs.add(makeSub(1, 300, true, "perl a.pl"));
+        append(subs, base);
+        append(subs, base + 60_000L);
+        append(subs, base + 120_000L);
+
+        // Only the middle record falls in [base+30s, base+90s].
+        List<String> mid = service.readSubProcessLog(base + 30_000L, base + 90_000L);
+        assertEquals(1, mid.size());
+        assertEquals(base + 60_000L, new org.json.JSONObject(mid.get(0)).getLong("timestamp"));
+
+        // Unbounded on one side.
+        assertEquals(2, service.readSubProcessLog(base + 60_000L, 0).size());
+        assertEquals(2, service.readSubProcessLog(0, base + 60_000L).size());
+        assertEquals(0, service.readSubProcessLog(base + 200_000L, 0).size());
+    }
+
+    public void testPurgeByAgeAndCount() throws Exception
+    {
+        File logFile = new File(tmpDir, MonitoringService.SUB_PROCESS_LOG_FILE);
+        File tmp = new File(tmpDir, "tmp.jsonl");
+
+        // Write 5 lines: 2 old (past 7-day age), 3 recent.
+        long now = 5_000_000_000L;
+        long weekMs = 7L * 24 * 60 * 60 * 1000;
+        String old = "{\"timestamp\":" + (now - weekMs - 1000) + ",\"subProcesses\":[]}";
+        String recent = "{\"timestamp\":" + (now - 1000) + ",\"subProcesses\":[]}";
+        try (OutputStreamWriter w = new OutputStreamWriter(new FileOutputStream(logFile), StandardCharsets.UTF_8))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                w.write(i < 2 ? old : recent);
+                w.write("\n");
+            }
+        }
+
+        boolean changed = purge(logFile, tmp, now);
+        assertTrue("purge should drop the 2 old lines", changed);
+
+        // After rename, 3 recent lines remain.
+        assertTrue(logFile.delete());
+        assertTrue(tmp.renameTo(logFile));
+        List<String> remaining = service.readSubProcessLog(0, 0);
+        assertEquals(3, remaining.size());
+    }
+
+    public void testExtractTimestamp() throws Exception
+    {
+        assertEquals(1234567890L, extractTimestamp("{\"timestamp\":1234567890,\"count\":1}"));
+        assertEquals(1234567890L, extractTimestamp("  garbage {\"timestamp\":1234567890} trailing"));
+        assertEquals(-1, extractTimestamp("{\"count\":1}"));
+        assertEquals(-1, extractTimestamp("no timestamp here"));
+    }
+}

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -336,13 +336,40 @@ public class TestSubProcessLog extends junit.framework.TestCase
                 "app --authorize=true",
                 redactCommand("app --authorize=true"));
 
-        // --- weak credential stems with real values ARE redacted ---
+        // --- component-based: --auth-token is strong (token component) ---
         assertEquals(
                 "app --auth-token=*** --verbose",
                 redactCommand("app --auth-token=abc123 --verbose"));
+
+        // --- component-based: --token-count is NOT a credential ---
+        // (the "count" component disqualifies the "token" component)
+        assertEquals(
+                "app --token-count=10 --verbose",
+                redactCommand("app --token-count=10 --verbose"));
+
+        // --- component-based: --secret-mode is NOT a credential ---
+        assertEquals(
+                "app --secret-mode=debug",
+                redactCommand("app --secret-mode=debug"));
+
+        // --- component-based: --password-policy is NOT a credential ---
+        assertEquals(
+                "app --password-policy=strict",
+                redactCommand("app --password-policy=strict"));
+
+        // --- weak credential stems with boolean values are NOT redacted ---
+        // (--authorize=true is a flag; "authorize" ≠ "auth")
+        assertEquals(
+                "app --authorize=true",
+                redactCommand("app --authorize=true"));
+
+        // --- weak credential stems with real values ARE redacted ---
         assertEquals(
                 "app --bearer=*** --verbose",
                 redactCommand("app --bearer=eyJhbGciOi --verbose"));
+        assertEquals(
+                "app --auth=*** --verbose",
+                redactCommand("app --auth=eyJhbGciOi --verbose"));
 
         // --- separate-token form: next token is an option, not a value ---
         // (--password --verbose must NOT eat --verbose as the password value)

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -380,7 +380,10 @@ public class TestSubProcessLog extends junit.framework.TestCase
                 "app --bearer=*** --verbose",
                 redactCommand("app --bearer=eyJhbGciOi --verbose"));
 
-        // --- camelCase: apiToken, clientSecret, APIKey ---
+        // --- camelCase: apiToken, clientSecret, APIKey, OAuthToken, HTTPToken ---
+        assertEquals(
+                "app --apiToken=***",
+                redactCommand("app --apiToken=secret"));
         assertEquals(
                 "app --apiKey=***",
                 redactCommand("app --apiKey=secret"));
@@ -390,12 +393,27 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(
                 "app --APIKey=***",
                 redactCommand("app --APIKey=secret"));
+        assertEquals(
+                "app --OAuthToken=***",
+                redactCommand("app --OAuthToken=secret"));
+        assertEquals(
+                "app --HTTPToken=***",
+                redactCommand("app --HTTPToken=secret"));
 
         // --- separate-token form: next token is an option, not a value ---
         // (--password --verbose must NOT eat --verbose as the password value)
         assertEquals(
                 "app --password --verbose",
                 redactCommand("app --password --verbose"));
+
+        // --- separate-token form: strong credentials redact regardless of
+        //     value appearance (no boolean guard on the separate-token path) ---
+        assertEquals(
+                "app --password ***",
+                redactCommand("app --password true"));
+        assertEquals(
+                "app --token ***",
+                redactCommand("app --token 1"));
 
         // --- bare flag at end of line (no value) is not redacted ---
         assertEquals(

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -336,40 +336,60 @@ public class TestSubProcessLog extends junit.framework.TestCase
                 "app --authorize=true",
                 redactCommand("app --authorize=true"));
 
-        // --- component-based: --auth-token is strong (token component) ---
+        // --- component-based: --auth-token is strong (exact sequence) ---
         assertEquals(
                 "app --auth-token=*** --verbose",
                 redactCommand("app --auth-token=abc123 --verbose"));
 
-        // --- component-based: --token-count is NOT a credential ---
-        // (the "count" component disqualifies the "token" component)
+        // --- exact-sequence: these are NOT credentials ---
+        // (extra components or wrong order disqualify the match)
+        assertEquals(
+                "app --api-key-mode=debug",
+                redactCommand("app --api-key-mode=debug"));
+        assertEquals(
+                "app --foo-api-key-bar=value",
+                redactCommand("app --foo-api-key-bar=value"));
+        assertEquals(
+                "app --auth-token-count=10",
+                redactCommand("app --auth-token-count=10"));
+        assertEquals(
+                "app --key-api=value",
+                redactCommand("app --key-api=value"));
         assertEquals(
                 "app --token-count=10 --verbose",
                 redactCommand("app --token-count=10 --verbose"));
-
-        // --- component-based: --secret-mode is NOT a credential ---
         assertEquals(
                 "app --secret-mode=debug",
                 redactCommand("app --secret-mode=debug"));
-
-        // --- component-based: --password-policy is NOT a credential ---
         assertEquals(
                 "app --password-policy=strict",
                 redactCommand("app --password-policy=strict"));
 
-        // --- weak credential stems with boolean values are NOT redacted ---
-        // (--authorize=true is a flag; "authorize" ≠ "auth")
+        // --- weak credential: exact single-component match ---
+        // (--authentication-mode, --authorize are NOT "auth")
+        assertEquals(
+                "app --authentication-mode=basic --verbose",
+                redactCommand("app --authentication-mode=basic --verbose"));
         assertEquals(
                 "app --authorize=true",
                 redactCommand("app --authorize=true"));
-
-        // --- weak credential stems with real values ARE redacted ---
-        assertEquals(
-                "app --bearer=*** --verbose",
-                redactCommand("app --bearer=eyJhbGciOi --verbose"));
         assertEquals(
                 "app --auth=*** --verbose",
                 redactCommand("app --auth=eyJhbGciOi --verbose"));
+        assertEquals(
+                "app --bearer=*** --verbose",
+                redactCommand("app --bearer=eyJhbGciOi --verbose"));
+
+        // --- camelCase: apiToken, clientSecret, APIKey ---
+        assertEquals(
+                "app --apiKey=***",
+                redactCommand("app --apiKey=secret"));
+        assertEquals(
+                "app --clientSecret=***",
+                redactCommand("app --clientSecret=secret"));
+        assertEquals(
+                "app --APIKey=***",
+                redactCommand("app --APIKey=secret"));
 
         // --- separate-token form: next token is an option, not a value ---
         // (--password --verbose must NOT eat --verbose as the password value)

--- a/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
+++ b/src/biouml/plugins/servermonitor/_test/TestSubProcessLog.java
@@ -41,6 +41,7 @@ public class TestSubProcessLog extends junit.framework.TestCase
         suite.addTest(new TestSubProcessLog("testPurgeByAge"));
         suite.addTest(new TestSubProcessLog("testPurgeByCountOverCap"));
         suite.addTest(new TestSubProcessLog("testPurgeDropsMalformedLines"));
+        suite.addTest(new TestSubProcessLog("testAppendSeedsCountCorrectly"));
         suite.addTest(new TestSubProcessLog("testExtractTimestamp"));
         suite.addTest(new TestSubProcessLog("testRedactCommand"));
         return suite;
@@ -249,6 +250,32 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(3, service.getSubProcessLogCount());
     }
 
+    /**
+     * Regression test: when the service starts with an existing log file and
+     * {@code subProcessLogCount == -1}, the first append must seed the count
+     * to the pre-append line count, then increment — NOT count the post-append
+     * file and then increment (which would give N+1).
+     */
+    public void testAppendSeedsCountCorrectly() throws Exception
+    {
+        File logFile = new File(tmpDir, MonitoringService.SUB_PROCESS_LOG_FILE);
+
+        // Pre-existing file with 3 lines.
+        long now = System.currentTimeMillis();
+        writeLines(logFile,
+                "{\"timestamp\":" + (now - 3000) + ",\"subProcesses\":[]}",
+                "{\"timestamp\":" + (now - 2000) + ",\"subProcesses\":[]}",
+                "{\"timestamp\":" + (now - 1000) + ",\"subProcesses\":[]}");
+
+        // Append one more record. subProcessLogCount is -1 (never seeded).
+        java.util.ArrayList<SubProcessMonitor.SubProcess> subs = new java.util.ArrayList<>();
+        subs.add(makeSub(42, 500, true, "perl test.pl"));
+        append(subs, now);
+
+        // The count must be exactly 4 (3 pre-existing + 1 appended), not 5.
+        assertEquals("count must be 4, not 5 (off-by-one)", 4, service.getSubProcessLogCount());
+    }
+
     public void testExtractTimestamp() throws Exception
     {
         assertEquals(1234567890L, extractTimestamp("{\"timestamp\":1234567890,\"count\":1}"));
@@ -287,25 +314,54 @@ public class TestSubProcessLog extends junit.framework.TestCase
         assertEquals(
                 "perl run.pl --very_long_parameter_name=value --input=in.csv",
                 redactCommand("perl run.pl --very_long_parameter_name=value --input=in.csv"));
+
+        // --- boolean flag values on strong credentials ARE still redacted ---
+        // (a password of "true" or a token of "1" is still a credential)
         assertEquals(
-                "perl run.pl --use-token=1",
-                redactCommand("perl run.pl --use-token=1"));
+                "app --password=***",
+                redactCommand("app --password=true"));
+        assertEquals(
+                "app --token=***",
+                redactCommand("app --token=1"));
+        assertEquals(
+                "app --secret=***",
+                redactCommand("app --secret=no"));
+
+        // --- weak credential stems with boolean values are NOT redacted ---
+        // (--authentication-mode=basic, --authorize=true are flags, not secrets)
+        assertEquals(
+                "app --authentication-mode=basic --verbose",
+                redactCommand("app --authentication-mode=basic --verbose"));
+        assertEquals(
+                "app --authorize=true",
+                redactCommand("app --authorize=true"));
+
+        // --- weak credential stems with real values ARE redacted ---
+        assertEquals(
+                "app --auth-token=*** --verbose",
+                redactCommand("app --auth-token=abc123 --verbose"));
+        assertEquals(
+                "app --bearer=*** --verbose",
+                redactCommand("app --bearer=eyJhbGciOi --verbose"));
+
+        // --- separate-token form: next token is an option, not a value ---
+        // (--password --verbose must NOT eat --verbose as the password value)
+        assertEquals(
+                "app --password --verbose",
+                redactCommand("app --password --verbose"));
 
         // --- bare flag at end of line (no value) is not redacted ---
         assertEquals(
                 "perl run.pl --password",
                 redactCommand("perl run.pl --password"));
 
-        // --- api-key / client_secret / auth variants ---
+        // --- api-key / client_secret variants ---
         assertEquals(
                 "curl --api-key=*** -u user",
                 redactCommand("curl --api-key=secret123 -u user"));
         assertEquals(
                 "app --client-secret *** --verbose",
                 redactCommand("app --client-secret topsecret --verbose"));
-        assertEquals(
-                "app --auth-token=*** --verbose",
-                redactCommand("app --auth-token=abc --verbose"));
 
         // No secret -> unchanged (exact string, not re-joined).
         assertEquals(

--- a/src/ru/biosoft/server/servlets/support/SupportServlet.java
+++ b/src/ru/biosoft/server/servlets/support/SupportServlet.java
@@ -1414,6 +1414,7 @@ public class SupportServlet extends AbstractJSONServlet
                 case "config":  return getMonitorConfig(params);
                 case "setConfig": return setMonitorConfig(params);
                 case "profileNow": return profileNow(params);
+                case "subProcessLog": return getSubProcessLog(params);
                 default:        return errorResponse("Unknown action: " + action);
             }
         }
@@ -1775,6 +1776,12 @@ public class SupportServlet extends AbstractJSONServlet
         }
         summary.append("\n");
 
+        // Slow sub-processes observed during this profile's time window — the
+        // external (perl/R/nextflow/...) work that the CPU profiler cannot see.
+        summary.append("--- Slow Sub-Processes (during profile window) ---\n");
+        appendSubProcessSummary(summary, baseName, profileDir);
+        summary.append("\n");
+
         // AI agent instructions
         summary.append("--- Instructions for AI Agent ---\n");
         summary.append("To suggest code improvements based on this profile:\n");
@@ -1790,6 +1797,167 @@ public class SupportServlet extends AbstractJSONServlet
         result.put("format", "text/markdown");
         result.put("content", summary.toString());
         return complexOkResponse(result);
+    }
+
+    /**
+     * Return the persistent sub-process observation log.
+     *
+     * <p>Each record is one scan (a JSON line) listing the external processes
+     * (perl / R / nextflow / ...) that were running at that moment, with their
+     * age and full command line. This is the historical complement to the live
+     * {@code status} snapshot: it survives process exit, so a slow external
+     * script that ran hours ago can still be inspected.
+     *
+     * <p>Optional parameters:
+     * <ul>
+     *   <li>{@code since} — earliest record timestamp (epoch millis), inclusive</li>
+     *   <li>{@code until} — latest record timestamp (epoch millis), inclusive</li>
+     *   <li>{@code slowOnly=true} — keep only scans that contained a slow (over-threshold) process</li>
+     * </ul>
+     */
+    protected JSONObject getSubProcessLog(Map params) throws Exception
+    {
+        try
+        {
+            biouml.plugins.servermonitor.ServerMonitorPlugin plugin = getServerMonitorPlugin();
+            if (plugin == null || plugin.getMonitoringService() == null)
+            {
+                return errorResponse("Monitoring service not available");
+            }
+
+            biouml.plugins.servermonitor.MonitoringService monitor = plugin.getMonitoringService();
+
+            long since = getLongParameter(params, "since", 0);
+            long until = getLongParameter(params, "until", 0);
+            boolean slowOnly = "true".equalsIgnoreCase(getStringParameter(params, "slowOnly"));
+
+            JSONArray records = new JSONArray();
+            for (String line : monitor.readSubProcessLog(since, until))
+            {
+                JSONObject rec;
+                try
+                {
+                    rec = new JSONObject(line);
+                }
+                catch (Exception e)
+                {
+                    continue; // skip malformed line
+                }
+                if (slowOnly)
+                {
+                    JSONArray subs = rec.optJSONArray("subProcesses");
+                    boolean anySlow = false;
+                    if (subs != null)
+                    {
+                        for (int i = 0; i < subs.length(); i++)
+                        {
+                            if (subs.getJSONObject(i).optBoolean("slow", false))
+                            {
+                                anySlow = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!anySlow) continue;
+                }
+                records.put(rec);
+            }
+
+            JSONObject result = new JSONObject();
+            result.put("path", monitor.getSubProcessLogPath());
+            result.put("count", records.length());
+            result.put("records", records);
+            return complexOkResponse(result);
+        }
+        catch (Exception e)
+        {
+            return errorResponse(e.getMessage());
+        }
+    }
+
+    /**
+     * Append a section listing the slow sub-processes observed during a profile's
+     * time window, reading the persistent sub-process log. The window is taken
+     * from the profile's {@code .json} metadata ({@code startTime}/{@code endTime});
+     * if that is unavailable the whole log is summarized (bounded to a few lines).
+     */
+    private void appendSubProcessSummary(StringBuilder summary, String baseName, File profileDir)
+    {
+        biouml.plugins.servermonitor.ServerMonitorPlugin plugin = getServerMonitorPlugin();
+        if (plugin == null || plugin.getMonitoringService() == null)
+        {
+            summary.append("Sub-process log unavailable (monitoring service not running)\n");
+            return;
+        }
+        biouml.plugins.servermonitor.MonitoringService monitor = plugin.getMonitoringService();
+
+        // Resolve the profile's time window from its metadata sidecar.
+        long since = 0;
+        long until = 0;
+        File metaFile = new File(profileDir, sanitizeFileName(baseName + ".json"));
+        if (metaFile.exists())
+        {
+            try
+            {
+                JSONObject meta = new JSONObject(readFileContent(metaFile));
+                since = meta.optLong("startTime", 0);
+                until = meta.optLong("endTime", 0);
+            }
+            catch (Exception e)
+            {
+                // fall through to unbounded read
+            }
+        }
+        // Give a little slack on each side so a scan that bracketed the window is
+        // still included (the monitor scans on a fixed cadence, not on profile
+        // start/stop).
+        long slack = 120_000L; // 2 minutes
+        long effSince = since > 0 ? Math.max(0, since - slack) : 0;
+        long effUntil = until > 0 ? until + slack : 0;
+
+        List<String> lines = monitor.readSubProcessLog(effSince, effUntil);
+        if (lines.isEmpty())
+        {
+            summary.append("No sub-processes recorded for this window (work was in-JVM, or the log is empty).\n");
+            return;
+        }
+
+        java.text.SimpleDateFormat fmt = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        int shown = 0;
+        for (String line : lines)
+        {
+            JSONObject rec;
+            try
+            {
+                rec = new JSONObject(line);
+            }
+            catch (Exception e)
+            {
+                continue;
+            }
+            JSONArray subs = rec.optJSONArray("subProcesses");
+            if (subs == null || subs.length() == 0) continue;
+            long ts = rec.optLong("timestamp", 0);
+            for (int i = 0; i < subs.length(); i++)
+            {
+                JSONObject sp = subs.getJSONObject(i);
+                if (!sp.optBoolean("slow", false)) continue; // summary only shows slow ones
+                summary.append(fmt.format(new Date(ts))).append("  pid=")
+                        .append(sp.optLong("pid"))
+                        .append(" age=").append(sp.optLong("ageSeconds")).append("s  ")
+                        .append(sp.optString("command"))
+                        .append("\n");
+                if (++shown >= 20)
+                {
+                    summary.append("... (").append(lines.size() - shown).append(" more records)\n");
+                    return;
+                }
+            }
+        }
+        if (shown == 0)
+        {
+            summary.append("Sub-processes were running in this window but none exceeded the slow threshold.\n");
+        }
     }
 
     /**
@@ -1852,6 +2020,8 @@ public class SupportServlet extends AbstractJSONServlet
                 // only sees the JVM itself.
                 status.put("subProcessEnabled", monitor.isSubProcessEnabled());
                 status.put("lastSubProcessCheck", monitor.getLastSubProcessCheckTime());
+                status.put("subProcessLogPath", monitor.getSubProcessLogPath());
+                status.put("subProcessLogCount", monitor.getSubProcessLogCount());
                 JSONArray subs = new JSONArray();
                 for (biouml.plugins.servermonitor.SubProcessMonitor.SubProcess sp : monitor.getSubProcesses())
                 {
@@ -2024,5 +2194,22 @@ public class SupportServlet extends AbstractJSONServlet
     {
         // Replace all non-alphanumeric characters (except ., _, -) with underscore
         return name.replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    /**
+     * Read a long parameter from the request map, falling back to a default if
+     * absent or not parseable.
+     */
+    private long getLongParameter(Map params, String key, long defaultValue)
+    {
+        String s = getStringParameter(params, key);
+        if (s == null || s.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
     }
 }

--- a/src/ru/biosoft/server/servlets/support/SupportServlet.java
+++ b/src/ru/biosoft/server/servlets/support/SupportServlet.java
@@ -1831,6 +1831,12 @@ public class SupportServlet extends AbstractJSONServlet
             long until = getLongParameter(params, "until", 0);
             boolean slowOnly = "true".equalsIgnoreCase(getStringParameter(params, "slowOnly"));
 
+            // Validate the time window: epoch-millis timestamps are non-negative,
+            // and until must not precede since.
+            if (since < 0 || until < 0 || (until > 0 && since > 0 && until < since)) {
+                return errorResponse("Invalid since/until: need since>=0, until>=0 and until>=since (epoch millis)");
+            }
+
             JSONArray records = new JSONArray();
             for (String line : monitor.readSubProcessLog(since, until))
             {
@@ -1880,6 +1886,8 @@ public class SupportServlet extends AbstractJSONServlet
      * time window, reading the persistent sub-process log. The window is taken
      * from the profile's {@code .json} metadata ({@code startTime}/{@code endTime});
      * if that is unavailable the whole log is summarized (bounded to a few lines).
+     * Command lines are already redacted at write time (see
+     * {@code MonitoringService#redactCommand}), so secrets never reach the summary.
      */
     private void appendSubProcessSummary(StringBuilder summary, String baseName, File profileDir)
     {
@@ -1923,6 +1931,31 @@ public class SupportServlet extends AbstractJSONServlet
         }
 
         java.text.SimpleDateFormat fmt = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        // First pass: collect the slow sub-processes we want to show, so the
+        // truncation message can report how many SLOW ENTRIES were omitted
+        // (not how many scan records).
+        int totalSlow = 0;
+        for (String line : lines)
+        {
+            JSONObject rec;
+            try
+            {
+                rec = new JSONObject(line);
+            }
+            catch (Exception e)
+            {
+                continue;
+            }
+            JSONArray subs = rec.optJSONArray("subProcesses");
+            if (subs == null || subs.length() == 0) continue;
+            for (int i = 0; i < subs.length(); i++)
+            {
+                if (subs.getJSONObject(i).optBoolean("slow", false))
+                    totalSlow++;
+            }
+        }
+
         int shown = 0;
         for (String line : lines)
         {
@@ -1949,7 +1982,8 @@ public class SupportServlet extends AbstractJSONServlet
                         .append("\n");
                 if (++shown >= 20)
                 {
-                    summary.append("... (").append(lines.size() - shown).append(" more records)\n");
+                    int remaining = totalSlow - shown;
+                    summary.append("... (").append(remaining).append(" more slow entries)\n");
                     return;
                 }
             }


### PR DESCRIPTION
The `SubProcessMonitor` detects long-running external processes (perl / R / nextflow / …) that async-profiler cannot see, but it only kept the **live snapshot** in memory (`status` API). Once a process exited there was no record of what it was or how long it ran. This makes that history durable and queryable.

## What changed

**Persistence** (`MonitoringService`)
- Every non-empty sub-process scan is appended to a JSON-lines log `subprocesses.jsonl` in the profiler dir. Each line is a self-contained record: `timestamp`, check/threshold config, and the process list (`pid`, `ageSeconds`, `slow`, full `command`).
- Self-bounding: 7-day age cap + 5000-line cap (purged in-place on append), and the file is **excluded from profile cleanup** so it is never accidentally deleted.

**API** (`SupportServlet`)
- New `action=subProcessLog[&slowOnly=true][&since=<epochMillis>][&until=<epochMillis>]` → returns the records, optionally slow-filtered and time-range filtered.
- `action=status` now also reports `subProcessLogPath` and `subProcessLogCount`.
- `action=summary` gains a **"Slow Sub-Processes (during profile window)"** section that reads the log for the profile's `[startTime,endTime]` (±2 min slack), so an agent analyzing a profile immediately sees off-JVM work explaining a slow task with an otherwise-idle CPU profile.

**Skill + fetch script** (`profiler-review`)
- New Step 1.5 + edge case: every review now pulls the sub-process log and cross-checks it against the CPU profile (the key signal is a profile that "looks idle" while the sub-process log shows a SLOW external process in the same window).
- `fetch_profile.sh` gains a `subprocess` action (`--slow-only`, `--since`, `--until`) that prints a readable table.

## Why it matters for optimization analysis
A slow task whose CPU profile is almost entirely `park`/`futex` waits used to be a dead end — the profiler can't see work done by a spawned script. Now the same review surfaces the actual `perl script.pl --opt1` cmdline and its runtime, pointing the analysis at the right place.

## Verification
- [x] `mvn package -DskipTests` passes
- [x] `cd src && ant compile` passes
- [x] `mvn -pl src test` — 749 tests pass
- [x] New `TestSubProcessLog` (4 tests): append/read, time-range filtering, age+count purging, timestamp extraction

## Notes
- The `subProcessLog` action requires a deployed build including this change; older deployments return an "Unknown action" error, which the fetch script degrades gracefully to "0 records".
- The live `ict.biouml.org` `status` endpoint currently shows `subProcessCount: 0` (all work is in-JVM), so the log is empty there — exactly the expected state.

Co-Authored-By: Claude <noreply@anthropic.com>