### PR TITLE
fix(servermonitor): bound profiler stop and child I/O, skip idle stops

### DIFF
--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -551,11 +551,22 @@ public class AsyncProfilerWrapper {
             // teardown.
         }
         // Destroy every captured descendant (order is unspecified and not
-        // relied upon), then the root.
+        // relied upon), then the root. Each kill is independent and best-effort:
+        // a failure on one handle (e.g. a stale/unavailable handle) must not
+        // prevent the rest of the tree — and in particular the root — from
+        // being killed.
         for (java.lang.ProcessHandle h : tree) {
-            h.destroyForcibly();
+            try {
+                h.destroyForcibly();
+            } catch (Exception ignored) {
+                // Best-effort teardown; continue killing the rest of the tree.
+            }
         }
-        process.destroyForcibly();
+        try {
+            process.destroyForcibly();
+        } catch (Exception ignored) {
+            // Best-effort teardown.
+        }
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -396,9 +396,9 @@ public class AsyncProfilerWrapper {
             log.log(Level.WARNING, "AsyncProfilerWrapper: error stopping profiler", e);
             exitedCleanly = false;
         } catch (InterruptedException e) {
-            // executeBounded already destroyed the stop process and re-set the
-            // interrupt flag before rethrowing.
-            Thread.currentThread().interrupt();
+            // executeBounded() already destroyed the stop process (and its
+            // tree) and re-set the interrupt flag before rethrowing; nothing
+            // further to do here.
             log.log(Level.WARNING, "AsyncProfilerWrapper: interrupted while stopping profiler", e);
             exitedCleanly = false;
         }
@@ -472,12 +472,17 @@ public class AsyncProfilerWrapper {
         TailBuffer tail = new TailBuffer(MAX_OUTPUT_TAIL_CHARS);
         java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
         Thread ioThread = new Thread(() -> {
+            // Read fixed-size chunks with Reader.read(char[]) rather than
+            // readLine(): a pathological child that streams a huge amount with
+            // no newlines would otherwise make readLine() accumulate an
+            // unbounded single line in memory, defeating the bounded-memory
+            // guarantee. A fixed read buffer bounds memory to the buffer size.
+            char[] chunk = new char[4096];
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
+                int n;
+                while ((n = reader.read(chunk)) != -1) {
                     synchronized (tail) {
-                        tail.append(line);
-                        tail.append("\n");
+                        tail.append(new String(chunk, 0, n));
                     }
                 }
             } catch (IOException ignored) {
@@ -521,16 +526,35 @@ public class AsyncProfilerWrapper {
      * Destroy a process and, best-effort, its descendants. {@code destroyForcibly}
      * kills the direct child but not necessarily its children (e.g. a shell
      * wrapper's {@code sleep}), which can keep the output pipe open and leak
-     * orphans. Killing the whole tree is the more reliable form of teardown.
+     * orphans.
+     *
+     * <p>Ordering matters: the descendant set is captured <em>before</em> the
+     * root is killed. Killing the root first can reparent/reap the children
+     * before {@code descendants()} is even evaluated, so they would never be
+     * reached. Once captured, the descendants are killed deepest-first (a child
+     * after its own children) so a lower process doesn't outlive the parent
+     * that is about to be torn down. This is best-effort — a descendant spawned
+     * concurrently with the kill can still be missed — but it is materially
+     * more reliable than killing the root first.
      */
     private void destroyProcessTree(Process process) {
-        process.destroyForcibly();
+        // Capture the tree while the root is still alive so the enumeration is
+        // complete, then tear it down.
+        List<java.lang.ProcessHandle> tree = new ArrayList<>();
         try {
-            process.toHandle().descendants().forEach(d -> d.destroyForcibly());
+            java.lang.ProcessHandle root = process.toHandle();
+            root.descendants().forEach(tree::add);
         } catch (Exception ignored) {
-            // Descendant enumeration is best-effort; the direct kill above is
-            // the primary teardown.
+            // Enumerating is best-effort; the direct kill below is the primary
+            // teardown.
         }
+        // Kill deepest-first: a process only after all of its descendants.
+        // The captured list is in pre-order (parent before child), so iterating
+        // it in reverse yields children before their parents.
+        for (int i = tree.size() - 1; i >= 0; i--) {
+            tree.get(i).destroyForcibly();
+        }
+        process.destroyForcibly();
     }
 
     /**
@@ -538,25 +562,55 @@ public class AsyncProfilerWrapper {
      * {@code capacity} characters, discarding the oldest beyond that. Used to
      * keep child-process output memory bounded while preserving the tail
      * (where errors usually appear).
+     *
+     * <p>Implemented as a small deque of fixed-size chunks rather than a
+     * single {@code StringBuilder}: appending is O(1) (no repeated shifting
+     * of up to {@code capacity} characters on every chunk), which matters when
+     * a verbose/hung process streams a lot.
      */
     private static final class TailBuffer {
+        private static final int CHUNK = 4096;
         private final int capacity;
-        private final StringBuilder sb = new StringBuilder();
+        private final java.util.ArrayDeque<String> chunks = new java.util.ArrayDeque<>();
+        private int total;
 
         TailBuffer(int capacity) {
             this.capacity = capacity;
         }
 
         synchronized void append(CharSequence s) {
-            sb.append(s);
-            int len = sb.length();
-            if (len > capacity) {
-                sb.delete(0, len - capacity);
+            // Split the input into CHUNK-sized pieces and enqueue them.
+            int len = s.length();
+            for (int i = 0; i < len; ) {
+                int n = Math.min(CHUNK, len - i);
+                chunks.addLast(s.subSequence(i, i + n).toString());
+                i += n;
+            }
+            total += len;
+            // Trim oldest chunks until the retained total is within capacity.
+            while (total > capacity && chunks.size() > 1) {
+                String oldest = chunks.removeFirst();
+                total -= oldest.length();
+            }
+            // If a single chunk still exceeds capacity (only possible if one
+            // append carried more than capacity), collapse to its own tail.
+            if (total > capacity) {
+                String only = chunks.removeFirst();
+                total = only.length();
+                if (total > capacity) {
+                    only = only.substring(only.length() - capacity);
+                    total = capacity;
+                }
+                chunks.addLast(only);
             }
         }
 
         @Override
         public synchronized String toString() {
+            StringBuilder sb = new StringBuilder(total);
+            for (String c : chunks) {
+                sb.append(c);
+            }
             return sb.toString();
         }
     }

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -42,6 +42,33 @@ public class AsyncProfilerWrapper {
     private static final int RUN_PROFILER_TIMEOUT_BUFFER_SECONDS = 60;
     /** Bounded wait (seconds) after destroyForcibly() to confirm the process actually exited. */
     private static final int KILL_WAIT_SECONDS = 5;
+    /** Bounded wait (seconds) to join the process-I/O drain thread after the child exits. */
+    private static final int IO_DRAIN_JOIN_SECONDS = 2;
+    /**
+     * Maximum characters of child-process output kept for diagnostics. The
+     * profiler output is only ever logged on a failure path (non-zero exit),
+     * so the tail is enough to diagnose the failure; capping it keeps memory
+     * bounded even if a hung/verbose profiler streams a lot to the pipe.
+     */
+    private static final int MAX_OUTPUT_CAPTURE_CHARS = 16384;
+
+    /**
+     * Optional test override for the per-run timeout (seconds). When > 0 the
+     * run timeout is this value INSTEAD OF {@code duration + buffer}, letting
+     * unit tests exercise the hang/destroy path in seconds. The production
+     * path never sets this (it stays 0), so behavior is unchanged.
+     */
+    private volatile int testRunTimeoutOverride = 0;
+
+    /**
+     * Test-only: force the per-run timeout to {@code timeoutSeconds}.
+     * A value <= 0 clears the override and restores the normal
+     * {@code duration + RUN_PROFILER_TIMEOUT_BUFFER_SECONDS} timeout.
+     * Not part of the production API.
+     */
+    public void setTestRunTimeout(int timeoutSeconds) {
+        this.testRunTimeoutOverride = timeoutSeconds;
+    }
 
     private final ServerMonitorConfig config;
     private String profilerPath;
@@ -107,12 +134,13 @@ public class AsyncProfilerWrapper {
             return new ProfilerResult("async-profiler is not available");
         }
 
-        // No explicit stop() here: runProfiler uses `asprof -d <duration>` which
-        // auto-stops when the duration expires. A separate `asprof stop` call
-        // was causing hangs (observed on strange_gx) when the previous session
-        // had already ended but the agent couldn't confirm the stop. If a
-        // previous session is somehow still running, the new `asprof -d` will
-        // fail with a clear error rather than hanging.
+        // No explicit stop() here: runProfiler() decides per-invocation
+        // whether an in-progress session needs to be cleared first (see the
+        // pre-run guard there). A blanket `asprof stop` before every run was
+        // causing hangs (strange_gx) and, on ict, a 30s timeout wait on every
+        // 60s monitoring cycle when the agent was stuck. If a previous
+        // session is somehow still running, the new `asprof -d` fails with a
+        // clear error rather than hanging.
 
         // Get JVM PID
         long jvmPid = getJvmPid();
@@ -139,10 +167,14 @@ public class AsyncProfilerWrapper {
         String primaryPath = buildOutputPath(baseName, format);
 
         try {
-            // Run 1: Primary format
+            // Run 1: Primary format. runProfiler() sets activeProfileOutputPath
+            // while its `asprof -d` runs and clears it in a finally block, so
+            // getProfileStatus() reflects the live state and the pre-run stop
+            // guard knows when a session is actually in progress.
             boolean primaryOk = runProfiler(jvmPid, threadIdStr, duration, primaryPath, format);
 
-            // Run 2: Generate extra formats for AI agent use
+            // Run 2: Generate extra formats for AI agent use. Each extra run
+            // is a fresh `asprof -d` invocation with the same pre-run guard.
             String[] extraPaths = null;
             if (generateSecondary && primaryOk) {
                 String extra = config.getExtraFormats();
@@ -167,16 +199,12 @@ public class AsyncProfilerWrapper {
             long endTime = System.currentTimeMillis();
 
             if (primaryOk && new File(primaryPath).exists()) {
-                activeProfileOutputPath = primaryPath;
+                // Profiler runs synchronously — once we return the process has
+                // exited and runProfiler's finally block has cleared the
+                // active marker, so getProfileStatus() reports "stopped".
                 String[] tidStrs = threadIdStr.isEmpty() ? new String[0] : threadIdStr.split(",");
-                ProfilerResult profResult = new ProfilerResult(primaryPath, startTime, endTime,
-                        tidStrs.length, tidStrs, format,
-                        extraPaths);
-                // Profiler runs synchronously — once we return the process has exited.
-                // Clear the path so getProfileStatus() reports "stopped" instead of
-                // incorrectly reporting "profiling" after the session ends.
-                activeProfileOutputPath = null;
-                return profResult;
+                return new ProfilerResult(primaryPath, startTime, endTime,
+                        tidStrs.length, tidStrs, format, extraPaths);
             } else {
                 return new ProfilerResult("Profiler exited with code " + (primaryOk ? 0 : 1));
             }
@@ -193,7 +221,9 @@ public class AsyncProfilerWrapper {
      */
     private boolean runProfiler(long jvmPid, String threadIdStr, int duration, String outputPath, String outputFormat)
             throws IOException, InterruptedException {
-        // Clear any previous profiling session before starting a new one.
+        // Clear a previous profiling session only if a run is actually
+        // in progress in this JVM (start() sets activeProfileOutputPath
+        // while its `asprof -d` runs, and clears it when the run returns).
         //
         // async-profiler keeps the agent (libasyncProfiler.so) installed in
         // the JVM between runs. If a prior session's auto-stop did not fully
@@ -203,6 +233,15 @@ public class AsyncProfilerWrapper {
         // nothing to clear it short of a restart. `asprof stop` tells the
         // agent to release, so run it first.
         //
+        // When NO run is active there is nothing to stop — and calling
+        // `asprof stop` then anyway is what the pre-run guard was doing on
+        // every 60s monitoring cycle on ict: when the agent is stuck (a
+        // prior CLI was SIGKILLed during teardown), every one of those stops
+        // hangs the full STOP_TIMEOUT_SECONDS before being destroyed, which
+        // both spams the log and delays every profiling run by 30s. Skipping
+        // the stop in the idle case avoids that; a genuinely active session
+        // still gets the bounded stop + lingering-process fallback below.
+        //
         // stop() is bounded (STOP_TIMEOUT_SECONDS + destroyForcibly), so it
         // cannot hang the monitoring thread — the reason it was previously
         // removed from this path. When it exits cleanly we KNOW the agent is
@@ -211,15 +250,17 @@ public class AsyncProfilerWrapper {
         // hold the agent too) and only start if we can confirm the tree is
         // clean — otherwise skip rather than risk a SIGKILL racing another
         // in-progress profiler.
-        boolean stopClean = stop();
-        if (!stopClean) {
-            log.info("AsyncProfilerWrapper: stop() did not exit cleanly; "
-                    + "checking for lingering profiler processes");
-            if (!killLingeringProfilerProcesses(jvmPid)) {
-                log.warning("AsyncProfilerWrapper: profiler state could not be cleared "
-                        + "(stop timed out and lingering process still alive); "
-                        + "not starting a new profiler");
-                return false;
+        if (activeProfileOutputPath != null) {
+            boolean stopClean = stop();
+            if (!stopClean) {
+                log.info("AsyncProfilerWrapper: stop() did not exit cleanly; "
+                        + "checking for lingering profiler processes");
+                if (!killLingeringProfilerProcesses(jvmPid)) {
+                    log.warning("AsyncProfilerWrapper: profiler state could not be cleared "
+                            + "(stop timed out and lingering process still alive); "
+                            + "not starting a new profiler");
+                    return false;
+                }
             }
         }
 
@@ -256,47 +297,83 @@ public class AsyncProfilerWrapper {
         pb.redirectErrorStream(true);
         Process process = pb.start();
 
-        // Capture stderr for debugging
-        StringBuilder stderr = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                stderr.append(line).append("\n");
+        // Advertise the in-progress run while its `asprof -d` is alive, so a
+        // concurrent start() sees an active session (and the pre-run guard in
+        // this method knows a stop is needed when a prior run is interrupted).
+        // start() is serialized by MonitoringService's profilerLock, so no two
+        // runs overlap; the flag simply spans this blocking call.
+        activeProfileOutputPath = outputPath;
+        try {
+            // Drain the process output on a daemon thread instead of reading it
+            // to EOF inline: a hung profiler keeps its pipe open, so an inline
+            // read would block forever (before the timeout was even reached),
+            // and a verbose/hung profiler that keeps writing >64KB of output
+            // fills the OS pipe and deadlocks the child once it stops
+            // responding. The daemon thread keeps the pipe draining until the
+            // child dies (destroyForcibly closes the stream and ends the
+            // reader), and only the last MAX_OUTPUT_CAPTURE_CHARS are kept for
+            // diagnostics — bounded memory by construction.
+            StringBuilder output = new StringBuilder();
+            java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+            Thread ioThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        synchronized (output) {
+                            if (output.length() < MAX_OUTPUT_CAPTURE_CHARS) {
+                                output.append(line).append("\n");
+                            }
+                        }
+                    }
+                } catch (IOException ignored) {
+                    // Stream closed by destroyForcibly() — expected on the
+                    // timeout path; the captured output so far is still used.
+                } finally {
+                    done.countDown();
+                }
+            });
+            ioThread.setName("AsyncProfilerWrapper-io-" + jvmPid);
+            ioThread.setDaemon(true);
+            ioThread.start();
+
+            // Use a timeout (duration + buffer) so a hung profiler process
+            // cannot block the monitoring thread indefinitely. A test override
+            // can shrink this for fast unit tests of the hang path.
+            int override = testRunTimeoutOverride;
+            long timeoutSeconds = override > 0
+                    ? override
+                    : duration + RUN_PROFILER_TIMEOUT_BUFFER_SECONDS;
+            if (!waitForProcessExit(process, timeoutSeconds, "profiler run")) {
+                return false;
             }
-        }
+            // Reap the I/O thread so a daemon cannot outlive this run.
+            done.await(IO_DRAIN_JOIN_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
 
-        // Use a timeout (duration + buffer) so a hung profiler process
-        // cannot block the monitoring thread indefinitely.
-        long timeoutSeconds = duration + RUN_PROFILER_TIMEOUT_BUFFER_SECONDS;
-        if (!process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)) {
-            log.warning("AsyncProfilerWrapper: profiler run timed out after " + timeoutSeconds
-                    + "s, destroying process");
-            process.destroyForcibly();
-            if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
-                log.warning("AsyncProfilerWrapper: profiler process did not exit within "
-                        + KILL_WAIT_SECONDS + "s after destroyForcibly");
+            String stderr = output.toString();
+            int exitCode = process.exitValue();
+            if (exitCode != 0) {
+                log.log(Level.WARNING, "AsyncProfilerWrapper: profiler exited with code " + exitCode + ". stderr: " + stderr);
+                return false;
             }
-            return false;
-        }
-        int exitCode = process.exitValue();
-        if (exitCode != 0) {
-            log.log(Level.WARNING, "AsyncProfilerWrapper: profiler exited with code " + exitCode + ". stderr: " + stderr);
-            return false;
-        }
 
-        // Verify the output file was actually created
-        File outputFile = new File(outputPath);
-        if (!outputFile.exists()) {
-            log.log(Level.WARNING,
-                    "AsyncProfilerWrapper: profiler exited successfully (code " + exitCode + ") "
-                            + "but output file was not created — path=" + outputPath
-                            + " exists=" + outputFile.exists()
-                            + " canWrite=" + outputFile.getParentFile().canWrite()
-                            + " parentExists=" + outputFile.getParentFile().exists());
-            return false;
-        }
+            // Verify the output file was actually created
+            File outputFile = new File(outputPath);
+            if (!outputFile.exists()) {
+                log.log(Level.WARNING,
+                        "AsyncProfilerWrapper: profiler exited successfully (code " + exitCode + ") "
+                                + "but output file was not created — path=" + outputPath
+                                + " exists=" + outputFile.exists()
+                                + " canWrite=" + outputFile.getParentFile().canWrite()
+                                + " parentExists=" + outputFile.getParentFile().exists());
+                return false;
+            }
 
-        return true;
+            return true;
+        } finally {
+            // Clear the in-progress marker even on error paths so the next
+            // run's pre-run guard sees a clean (idle) state.
+            activeProfileOutputPath = null;
+        }
     }
 
     /**
@@ -340,32 +417,59 @@ public class AsyncProfilerWrapper {
             }
             pb.redirectErrorStream(true);
             Process process = pb.start();
-            // Use a timeout so a hung `asprof stop` (e.g. when the profiler
-            // session already ended) cannot block the monitoring thread
-            // indefinitely.  The hang was observed on strange_gx where a
-            // stuck `asprof stop` killed all subsequent profiling.  Bounded
-            // here (STOP_TIMEOUT_SECONDS + destroyForcibly), so this stop is
-            // safe to call as a pre-run guard (see runProfiler).
-            if (!process.waitFor(STOP_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
-                log.warning("AsyncProfilerWrapper: stop timed out after " + STOP_TIMEOUT_SECONDS
-                        + "s, destroying process");
-                process.destroyForcibly();
-                if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
-                    log.warning("AsyncProfilerWrapper: stop process did not exit within "
-                            + KILL_WAIT_SECONDS + "s after destroyForcibly");
-                }
+            // Use a timeout so a hung `asprof stop` (e.g. when the agent is
+            // stuck after a prior CLI was killed mid-teardown) cannot block
+            // the monitoring thread indefinitely.  The hang was observed on
+            // strange_gx and ict (stop timed out on every 60s monitoring
+            // cycle).  Bounded here (STOP_TIMEOUT_SECONDS + destroyForcibly),
+            // so this stop is safe to call as a pre-run guard (see runProfiler).
+            if (!waitForProcessExit(process, STOP_TIMEOUT_SECONDS, "stop")) {
                 exitedCleanly = false;
             } else {
                 exitedCleanly = true;
                 log.info("AsyncProfilerWrapper: profiling stopped");
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (IOException e) {
             log.log(Level.WARNING, "AsyncProfilerWrapper: error stopping profiler", e);
+            exitedCleanly = false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.log(Level.WARNING, "AsyncProfilerWrapper: interrupted while stopping profiler", e);
             exitedCleanly = false;
         }
 
         activeProfileOutputPath = null;
         return exitedCleanly;
+    }
+
+    /**
+     * Wait for a profiler child process to exit within a bounded timeout,
+     * draining its output pipe in the meantime (see runProfiler).
+     * On timeout the process is destroyed forcefully and we make one
+     * bounded attempt to confirm it actually exited — a child that ignores
+     * SIGKILL is exceptional and is reported, not waited on forever.
+     *
+     * @param process the child process to wait for
+     * @param timeoutSeconds the maximum time to wait for a clean exit
+     * @param label short label for log messages (e.g. "stop", "profiler run")
+     * @return true if the process exited cleanly within the timeout; false
+     *         on timeout (after destroyForcibly) or if the process could not
+     *         be confirmed dead
+     */
+    private boolean waitForProcessExit(Process process, long timeoutSeconds, String label)
+            throws InterruptedException {
+        if (!process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)) {
+            log.warning("AsyncProfilerWrapper: " + label
+                    + " timed out after " + timeoutSeconds + "s, destroying process");
+            process.destroyForcibly();
+            if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
+                log.warning("AsyncProfilerWrapper: " + label + " process did not exit within "
+                        + KILL_WAIT_SECONDS + "s after destroyForcibly");
+                return false;
+            }
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -531,11 +531,13 @@ public class AsyncProfilerWrapper {
      * <p>Ordering matters: the descendant set is captured <em>before</em> the
      * root is killed. Killing the root first can reparent/reap the children
      * before {@code descendants()} is even evaluated, so they would never be
-     * reached. Once captured, the descendants are killed deepest-first (a child
-     * after its own children) so a lower process doesn't outlive the parent
-     * that is about to be torn down. This is best-effort — a descendant spawned
-     * concurrently with the kill can still be missed — but it is materially
-     * more reliable than killing the root first.
+     * reached. Once the snapshot is captured we destroy every captured
+     * descendant and then the root. {@code descendants()} does not document a
+     * traversal order, so we do not rely on one — for this teardown the only
+     * thing that matters is that the whole captured snapshot is killed. This is
+     * best-effort: a descendant spawned concurrently with the kill can still be
+     * missed, but capturing-first is materially more reliable than killing the
+     * root first.
      */
     private void destroyProcessTree(Process process) {
         // Capture the tree while the root is still alive so the enumeration is
@@ -548,11 +550,10 @@ public class AsyncProfilerWrapper {
             // Enumerating is best-effort; the direct kill below is the primary
             // teardown.
         }
-        // Kill deepest-first: a process only after all of its descendants.
-        // The captured list is in pre-order (parent before child), so iterating
-        // it in reverse yields children before their parents.
-        for (int i = tree.size() - 1; i >= 0; i--) {
-            tree.get(i).destroyForcibly();
+        // Destroy every captured descendant (order is unspecified and not
+        // relied upon), then the root.
+        for (java.lang.ProcessHandle h : tree) {
+            h.destroyForcibly();
         }
         process.destroyForcibly();
     }
@@ -563,10 +564,12 @@ public class AsyncProfilerWrapper {
      * keep child-process output memory bounded while preserving the tail
      * (where errors usually appear).
      *
-     * <p>Implemented as a small deque of fixed-size chunks rather than a
-     * single {@code StringBuilder}: appending is O(1) (no repeated shifting
-     * of up to {@code capacity} characters on every chunk), which matters when
-     * a verbose/hung process streams a lot.
+     * <p>Implemented as a deque of fixed-size chunks rather than a single
+     * {@code StringBuilder}: appends do not repeatedly shift a full
+     * {@code capacity} buffer, so a verbose/hung process streaming a lot stays
+     * cheap. Callers are expected to pass bounded-size chunks (the I/O drain
+     * feeds 4KB reads); a single append larger than the capacity is collapsed
+     * to its own tail so the bound still holds.
      */
     private static final class TailBuffer {
         private static final int CHUNK = 4096;

--- a/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/AsyncProfilerWrapper.java
@@ -45,12 +45,12 @@ public class AsyncProfilerWrapper {
     /** Bounded wait (seconds) to join the process-I/O drain thread after the child exits. */
     private static final int IO_DRAIN_JOIN_SECONDS = 2;
     /**
-     * Maximum characters of child-process output kept for diagnostics. The
-     * profiler output is only ever logged on a failure path (non-zero exit),
-     * so the tail is enough to diagnose the failure; capping it keeps memory
-     * bounded even if a hung/verbose profiler streams a lot to the pipe.
+     * Maximum number of characters of child-process output kept for
+     * diagnostics. Only the TAIL of this size is retained (the error is
+     * usually at the end), so memory stays bounded even if a hung/verbose
+     * profiler streams a lot to the pipe.
      */
-    private static final int MAX_OUTPUT_CAPTURE_CHARS = 16384;
+    private static final int MAX_OUTPUT_TAIL_CHARS = 16384;
 
     /**
      * Optional test override for the per-run timeout (seconds). When > 0 the
@@ -73,7 +73,22 @@ public class AsyncProfilerWrapper {
     private final ServerMonitorConfig config;
     private String profilerPath;
     private volatile boolean profilerAvailable = false;
+    /**
+     * Output path of the profile this wrapper instance is currently
+     * generating, or null when idle. Drives {@link #getProfileStatus()}.
+     * Cleared in {@link #stop()} and after a run completes.
+     */
     private volatile String activeProfileOutputPath = null;
+    /**
+     * Whether this wrapper instance currently has an in-progress
+     * {@code asprof -d} run. Set/cleared around the synchronous run in
+     * {@link #runProfiler}. This is the pre-run stop guard's signal — it is
+     * deliberately LOCAL to this instance (it does not probe the agent), so
+     * it can go stale only if this JVM was killed mid-run and the agent was
+     * left installed; that case is handled by the run failing with the real
+     * async-profiler error until a restart clears the agent.
+     */
+    private volatile boolean profilerRunActive = false;
 
     public AsyncProfilerWrapper(ServerMonitorConfig config) {
         this.config = config;
@@ -167,10 +182,11 @@ public class AsyncProfilerWrapper {
         String primaryPath = buildOutputPath(baseName, format);
 
         try {
-            // Run 1: Primary format. runProfiler() sets activeProfileOutputPath
-            // while its `asprof -d` runs and clears it in a finally block, so
-            // getProfileStatus() reflects the live state and the pre-run stop
-            // guard knows when a session is actually in progress.
+            // Run 1: Primary format. runProfiler() sets profilerRunActive and
+            // activeProfileOutputPath while its `asprof -d` runs and clears
+            // them in a finally block, so getProfileStatus() reflects the live
+            // state and the pre-run stop guard knows when a session is
+            // actually in progress.
             boolean primaryOk = runProfiler(jvmPid, threadIdStr, duration, primaryPath, format);
 
             // Run 2: Generate extra formats for AI agent use. Each extra run
@@ -221,9 +237,9 @@ public class AsyncProfilerWrapper {
      */
     private boolean runProfiler(long jvmPid, String threadIdStr, int duration, String outputPath, String outputFormat)
             throws IOException, InterruptedException {
-        // Clear a previous profiling session only if a run is actually
-        // in progress in this JVM (start() sets activeProfileOutputPath
-        // while its `asprof -d` runs, and clears it when the run returns).
+        // Clear a previous profiling session only if this wrapper instance
+        // has a run in progress (profilerRunActive, set/cleared around the
+        // synchronous `asprof -d` below).
         //
         // async-profiler keeps the agent (libasyncProfiler.so) installed in
         // the JVM between runs. If a prior session's auto-stop did not fully
@@ -233,14 +249,16 @@ public class AsyncProfilerWrapper {
         // nothing to clear it short of a restart. `asprof stop` tells the
         // agent to release, so run it first.
         //
-        // When NO run is active there is nothing to stop — and calling
-        // `asprof stop` then anyway is what the pre-run guard was doing on
-        // every 60s monitoring cycle on ict: when the agent is stuck (a
-        // prior CLI was SIGKILLed during teardown), every one of those stops
-        // hangs the full STOP_TIMEOUT_SECONDS before being destroyed, which
-        // both spams the log and delays every profiling run by 30s. Skipping
-        // the stop in the idle case avoids that; a genuinely active session
-        // still gets the bounded stop + lingering-process fallback below.
+        // This is deliberately LOCAL knowledge: profilerRunActive only says
+        // "this instance started a run that is still in flight", it does NOT
+        // probe the agent. So if this JVM was killed mid-run and the agent
+        // was left installed, a fresh instance sees profilerRunActive ==
+        // false and skips the stop; the subsequent `asprof -d` then fails
+        // with the real async-profiler error (rather than hanging on a
+        // useless `asprof stop` that would time out on a stuck agent every
+        // 60s monitoring cycle — the ict log-spam regression). A genuinely
+        // in-progress run still gets the bounded stop + lingering-process
+        // fallback below.
         //
         // stop() is bounded (STOP_TIMEOUT_SECONDS + destroyForcibly), so it
         // cannot hang the monitoring thread — the reason it was previously
@@ -250,7 +268,7 @@ public class AsyncProfilerWrapper {
         // hold the agent too) and only start if we can confirm the tree is
         // clean — otherwise skip rather than risk a SIGKILL racing another
         // in-progress profiler.
-        if (activeProfileOutputPath != null) {
+        if (profilerRunActive) {
             boolean stopClean = stop();
             if (!stopClean) {
                 log.info("AsyncProfilerWrapper: stop() did not exit cleanly; "
@@ -283,59 +301,14 @@ public class AsyncProfilerWrapper {
         // PID is a positional argument at the end (not -j)
         command.add(String.valueOf(jvmPid));
 
-        ProcessBuilder pb = new ProcessBuilder(command);
-        // Set LD_LIBRARY_PATH to include the profiler's lib directory
-        String profilerDir = new File(profilerPath).getParent();
-        String libPath = profilerDir + "/lib";
-        Map<String, String> env = pb.environment();
-        String existingLibPath = env.get("LD_LIBRARY_PATH");
-        if (existingLibPath != null) {
-            env.put("LD_LIBRARY_PATH", libPath + ":" + existingLibPath);
-        } else {
-            env.put("LD_LIBRARY_PATH", libPath);
-        }
-        pb.redirectErrorStream(true);
-        Process process = pb.start();
-
         // Advertise the in-progress run while its `asprof -d` is alive, so a
         // concurrent start() sees an active session (and the pre-run guard in
         // this method knows a stop is needed when a prior run is interrupted).
         // start() is serialized by MonitoringService's profilerLock, so no two
-        // runs overlap; the flag simply spans this blocking call.
+        // runs overlap; the flags simply span this blocking call.
+        profilerRunActive = true;
         activeProfileOutputPath = outputPath;
         try {
-            // Drain the process output on a daemon thread instead of reading it
-            // to EOF inline: a hung profiler keeps its pipe open, so an inline
-            // read would block forever (before the timeout was even reached),
-            // and a verbose/hung profiler that keeps writing >64KB of output
-            // fills the OS pipe and deadlocks the child once it stops
-            // responding. The daemon thread keeps the pipe draining until the
-            // child dies (destroyForcibly closes the stream and ends the
-            // reader), and only the last MAX_OUTPUT_CAPTURE_CHARS are kept for
-            // diagnostics — bounded memory by construction.
-            StringBuilder output = new StringBuilder();
-            java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
-            Thread ioThread = new Thread(() -> {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        synchronized (output) {
-                            if (output.length() < MAX_OUTPUT_CAPTURE_CHARS) {
-                                output.append(line).append("\n");
-                            }
-                        }
-                    }
-                } catch (IOException ignored) {
-                    // Stream closed by destroyForcibly() — expected on the
-                    // timeout path; the captured output so far is still used.
-                } finally {
-                    done.countDown();
-                }
-            });
-            ioThread.setName("AsyncProfilerWrapper-io-" + jvmPid);
-            ioThread.setDaemon(true);
-            ioThread.start();
-
             // Use a timeout (duration + buffer) so a hung profiler process
             // cannot block the monitoring thread indefinitely. A test override
             // can shrink this for fast unit tests of the hang path.
@@ -343,14 +316,13 @@ public class AsyncProfilerWrapper {
             long timeoutSeconds = override > 0
                     ? override
                     : duration + RUN_PROFILER_TIMEOUT_BUFFER_SECONDS;
-            if (!waitForProcessExit(process, timeoutSeconds, "profiler run")) {
+            BoundedProcess run = executeBounded(command, timeoutSeconds, "profiler run");
+
+            String stderr = run.output.toString();
+            if (run.timedOut) {
                 return false;
             }
-            // Reap the I/O thread so a daemon cannot outlive this run.
-            done.await(IO_DRAIN_JOIN_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
-
-            String stderr = output.toString();
-            int exitCode = process.exitValue();
+            int exitCode = run.exitCode;
             if (exitCode != 0) {
                 log.log(Level.WARNING, "AsyncProfilerWrapper: profiler exited with code " + exitCode + ". stderr: " + stderr);
                 return false;
@@ -370,8 +342,10 @@ public class AsyncProfilerWrapper {
 
             return true;
         } finally {
-            // Clear the in-progress marker even on error paths so the next
-            // run's pre-run guard sees a clean (idle) state.
+            // Clear the in-progress markers even on error paths so the next
+            // run's pre-run guard sees a clean (idle) state and
+            // getProfileStatus() reports "stopped".
+            profilerRunActive = false;
             activeProfileOutputPath = null;
         }
     }
@@ -394,10 +368,16 @@ public class AsyncProfilerWrapper {
             return false;
         }
 
-        // Run the bounded stop. Returns true only if the stop process exited
-        // on its own within the timeout (i.e. the profiler was cleanly stopped
-        // or already not running). A timeout + destroyForcibly means the agent
-        // may still be active, so we return false so a caller can fall back.
+        // Run the bounded stop through the same shared executor as runProfiler
+        // (output drained on a daemon thread, bounded wait, destroyForcibly on
+        // timeout, process destroyed on interruption). Returns true only if
+        // the stop process exited on its own within the timeout (i.e. the
+        // profiler was cleanly stopped or already not running). A timeout +
+        // destroyForcibly means the agent may still be active, so we return
+        // false so a caller can fall back to killing lingering processes.
+        // The hang was observed on strange_gx and ict (stop timed out on every
+        // 60s monitoring cycle when the agent was stuck); bounding it here
+        // keeps it safe to call as a pre-run guard.
         boolean exitedCleanly;
         try {
             List<String> command = new ArrayList<>();
@@ -405,71 +385,180 @@ public class AsyncProfilerWrapper {
             command.add("stop");
             command.add(String.valueOf(jvmPid));
 
-            ProcessBuilder pb = new ProcessBuilder(command);
-            String profilerDir = new File(profilerPath).getParent();
-            String libPath = profilerDir + "/lib";
-            Map<String, String> env = pb.environment();
-            String existingLibPath = env.get("LD_LIBRARY_PATH");
-            if (existingLibPath != null) {
-                env.put("LD_LIBRARY_PATH", libPath + ":" + existingLibPath);
-            } else {
-                env.put("LD_LIBRARY_PATH", libPath);
-            }
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-            // Use a timeout so a hung `asprof stop` (e.g. when the agent is
-            // stuck after a prior CLI was killed mid-teardown) cannot block
-            // the monitoring thread indefinitely.  The hang was observed on
-            // strange_gx and ict (stop timed out on every 60s monitoring
-            // cycle).  Bounded here (STOP_TIMEOUT_SECONDS + destroyForcibly),
-            // so this stop is safe to call as a pre-run guard (see runProfiler).
-            if (!waitForProcessExit(process, STOP_TIMEOUT_SECONDS, "stop")) {
-                exitedCleanly = false;
-            } else {
+            BoundedProcess stop = executeBounded(command, STOP_TIMEOUT_SECONDS, "stop");
+            if (!stop.timedOut) {
                 exitedCleanly = true;
                 log.info("AsyncProfilerWrapper: profiling stopped");
+            } else {
+                exitedCleanly = false;
             }
         } catch (IOException e) {
             log.log(Level.WARNING, "AsyncProfilerWrapper: error stopping profiler", e);
             exitedCleanly = false;
         } catch (InterruptedException e) {
+            // executeBounded already destroyed the stop process and re-set the
+            // interrupt flag before rethrowing.
             Thread.currentThread().interrupt();
             log.log(Level.WARNING, "AsyncProfilerWrapper: interrupted while stopping profiler", e);
             exitedCleanly = false;
         }
 
-        activeProfileOutputPath = null;
         return exitedCleanly;
     }
 
     /**
-     * Wait for a profiler child process to exit within a bounded timeout,
-     * draining its output pipe in the meantime (see runProfiler).
-     * On timeout the process is destroyed forcefully and we make one
-     * bounded attempt to confirm it actually exited — a child that ignores
-     * SIGKILL is exceptional and is reported, not waited on forever.
+     * Result of a bounded child-process execution.
+     */
+    private static final class BoundedProcess {
+        /** True if the process was destroyed on timeout/interruption (not a clean exit). */
+        final boolean timedOut;
+        /** Exit code, valid only when {@link #timedOut} is false. */
+        final int exitCode;
+        /** Tail of the process output (stdout+stderr) for diagnostics. */
+        final TailBuffer output;
+
+        BoundedProcess(boolean timedOut, int exitCode, TailBuffer output) {
+            this.timedOut = timedOut;
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+    }
+
+    /**
+     * Run a profiler child process with bounded, non-blocking I/O.
      *
-     * @param process the child process to wait for
+     * <p>Both {@link #runProfiler} and {@link #stop} go through here so that
+     * the I/O-drain / bounded-wait / destroy-on-timeout behavior is shared and
+     * cannot drift. The child's combined stdout+stderr is drained on a daemon
+     * thread (keeping the OS pipe from filling, which would otherwise deadlock
+     * a child that keeps writing, and so the caller is never blocked reading
+     * before the timeout is even reached). Only the TAIL of
+     * {@link #MAX_OUTPUT_TAIL_CHARS} is retained for diagnostics.
+     *
+     * <p>On timeout the process (and, best-effort, its descendants) is
+     * destroyed forcefully and one bounded attempt is made to confirm it
+     * exited — a child that ignores SIGKILL is exceptional and reported, not
+     * waited on forever.
+     *
+     * @param command the command to run (profiler binary + args)
      * @param timeoutSeconds the maximum time to wait for a clean exit
      * @param label short label for log messages (e.g. "stop", "profiler run")
-     * @return true if the process exited cleanly within the timeout; false
-     *         on timeout (after destroyForcibly) or if the process could not
-     *         be confirmed dead
+     * @return a {@link BoundedProcess}; {@code timedOut} is true on timeout or
+     *         interruption (in which case {@code exitCode} is meaningless)
+     * @throws IOException if the process could not be started
+     * @throws InterruptedException if the wait was interrupted; the process is
+     *         destroyed and the interrupt flag re-set before rethrowing
      */
-    private boolean waitForProcessExit(Process process, long timeoutSeconds, String label)
-            throws InterruptedException {
-        if (!process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)) {
-            log.warning("AsyncProfilerWrapper: " + label
-                    + " timed out after " + timeoutSeconds + "s, destroying process");
-            process.destroyForcibly();
-            if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
-                log.warning("AsyncProfilerWrapper: " + label + " process did not exit within "
-                        + KILL_WAIT_SECONDS + "s after destroyForcibly");
-                return false;
-            }
-            return false;
+    private BoundedProcess executeBounded(List<String> command, long timeoutSeconds, String label)
+            throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        // Set LD_LIBRARY_PATH to include the profiler's lib directory.
+        String profilerDir = new File(profilerPath).getParent();
+        String libPath = profilerDir + "/lib";
+        Map<String, String> env = pb.environment();
+        String existingLibPath = env.get("LD_LIBRARY_PATH");
+        if (existingLibPath != null) {
+            env.put("LD_LIBRARY_PATH", libPath + ":" + existingLibPath);
+        } else {
+            env.put("LD_LIBRARY_PATH", libPath);
         }
-        return true;
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+
+        // Drain the combined output on a daemon thread. The pipe is kept
+        // draining until the child dies, so a hung/verbose child can neither
+        // block the caller (we never read inline) nor deadlock itself by
+        // filling the pipe. The tail buffer caps memory.
+        TailBuffer tail = new TailBuffer(MAX_OUTPUT_TAIL_CHARS);
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+        Thread ioThread = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    synchronized (tail) {
+                        tail.append(line);
+                        tail.append("\n");
+                    }
+                }
+            } catch (IOException ignored) {
+                // Stream closed (child destroyed, or it exited) — expected;
+                // whatever was captured so far is still used.
+            } finally {
+                done.countDown();
+            }
+        });
+        ioThread.setName("AsyncProfilerWrapper-io-" + label);
+        ioThread.setDaemon(true);
+        ioThread.start();
+
+        try {
+            if (!process.waitFor(timeoutSeconds, java.util.concurrent.TimeUnit.SECONDS)) {
+                log.warning("AsyncProfilerWrapper: " + label
+                        + " timed out after " + timeoutSeconds + "s, destroying process");
+                destroyProcessTree(process);
+                if (!process.waitFor(KILL_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)) {
+                    log.warning("AsyncProfilerWrapper: " + label + " process did not exit within "
+                            + KILL_WAIT_SECONDS + "s after destroyForcibly");
+                }
+                done.await(IO_DRAIN_JOIN_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+                return new BoundedProcess(true, -1, tail);
+            }
+            int exitCode = process.exitValue();
+            // Reap the I/O thread so a daemon cannot outlive this run.
+            done.await(IO_DRAIN_JOIN_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+            return new BoundedProcess(false, exitCode, tail);
+        } catch (InterruptedException e) {
+            // A cleanup method must not leave its child running: destroy it
+            // (and descendants) before propagating the interruption.
+            destroyProcessTree(process);
+            done.await(IO_DRAIN_JOIN_SECONDS, java.util.concurrent.TimeUnit.SECONDS);
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+    }
+
+    /**
+     * Destroy a process and, best-effort, its descendants. {@code destroyForcibly}
+     * kills the direct child but not necessarily its children (e.g. a shell
+     * wrapper's {@code sleep}), which can keep the output pipe open and leak
+     * orphans. Killing the whole tree is the more reliable form of teardown.
+     */
+    private void destroyProcessTree(Process process) {
+        process.destroyForcibly();
+        try {
+            process.toHandle().descendants().forEach(d -> d.destroyForcibly());
+        } catch (Exception ignored) {
+            // Descendant enumeration is best-effort; the direct kill above is
+            // the primary teardown.
+        }
+    }
+
+    /**
+     * A bounded output sink that retains only the trailing
+     * {@code capacity} characters, discarding the oldest beyond that. Used to
+     * keep child-process output memory bounded while preserving the tail
+     * (where errors usually appear).
+     */
+    private static final class TailBuffer {
+        private final int capacity;
+        private final StringBuilder sb = new StringBuilder();
+
+        TailBuffer(int capacity) {
+            this.capacity = capacity;
+        }
+
+        synchronized void append(CharSequence s) {
+            sb.append(s);
+            int len = sb.length();
+            if (len > capacity) {
+                sb.delete(0, len - capacity);
+            }
+        }
+
+        @Override
+        public synchronized String toString() {
+            return sb.toString();
+        }
     }
 
     /**

--- a/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
@@ -141,8 +141,11 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
      * have the WHOLE tree torn down — not just the direct child. This is the
      * scenario the earlier review flagged: a shell's child (e.g. {@code sleep})
      * survives a plain {@code destroyForcibly()} of the shell, keeps the output
-     * pipe open, and leaks. We assert both the wrapper process and its child
-     * disappear.
+     * pipe open, and leaks.
+     *
+     * <p>The fake records the child's PID in a file, so the test checks
+     * {@code /proc/<childPid>} directly — a deterministic identification of the
+     * process the test itself created, rather than a command-line scan.
      */
     public void testHungProcessTreeIsBoundedAndDestroyed() throws Exception
     {
@@ -160,19 +163,23 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
                 + "(should be bounded by ~3s timeout + 5s kill-confirm)",
                 elapsedMs < 12000);
 
-        // The hang is a shell wrapper (parent) plus a `sleep 600` child. Both
-        // must be gone; a leak of the child means the process-tree teardown
-        // (descendants() kill) did not work.
-        String marker = "asprof-test-tree-" + tmpDir.getName();
+        // The fake spawned a real `sleep 600` child and recorded its PID.
+        // That child (the shell wrapper's descendant) must be gone; a leak
+        // means the process-tree teardown (descendants() kill) did not work.
+        File pidFile = new File(tmpDir, "tree_child.pid");
+        assertTrue("expected the fake profiler to record its child PID in "
+                + pidFile, pidFile.exists());
+        long childPid = Long.parseLong(new String(Files.readAllBytes(pidFile.toPath())).trim());
+        assertTrue("expected a plausible child PID, got " + childPid, childPid > 0);
+
+        File childProc = new File("/proc/" + childPid);
         long deadline = System.currentTimeMillis() + 5000;
-        while (System.currentTimeMillis() < deadline) {
-            if (listPidsRunningMarker(marker).isEmpty()) break;
+        while (childProc.exists() && System.currentTimeMillis() < deadline) {
             Thread.sleep(100);
         }
-        java.util.List<String> leftover = listPidsRunningMarker(marker);
-        assertTrue("expected the whole hung fake profiler process tree "
-                + "(wrapper + child) to be destroyed, but found still running: "
-                + leftover, leftover.isEmpty());
+        assertFalse("expected the hung fake profiler's child (PID " + childPid
+                + ") to be destroyed by the process-tree teardown, but "
+                + "/proc/" + childPid + " still exists", childProc.exists());
     }
 
     /** A profiler that exits non-zero is reported as a failed result. */
@@ -269,10 +276,10 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
             + "  shift\n"
             + "done\n"
             + "sleep 0.2\n"
-            + "TREE_MARKER=\"asprof-test-tree-" + tmpDir.getName() + "\"\n"
+            + "TREE_PID_FILE=\"" + tmpDir.getAbsolutePath() + "/tree_child.pid\"\n"
             + "case \"" + mode + "\" in\n"
             + "  hung) exec sleep 600 ;;\n"
-            + "  tree) TREE_MARKER=\"$TREE_MARKER\" /bin/sh -c 'sleep 600 \"$TREE_MARKER\"' & wait ;;\n"
+            + "  tree) sleep 600 & echo $! > \"$TREE_PID_FILE\"; wait ;;\n"
             + "  clean) [ -n \"$F\" ] && touch \"$F\"; exit 0 ;;\n"
             + "  fail) exit 1 ;;\n"
             + "esac\n";

--- a/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
@@ -1,0 +1,220 @@
+package biouml.plugins.servermonitor._test;
+
+import biouml.plugins.servermonitor.AsyncProfilerWrapper;
+import biouml.plugins.servermonitor.ProfilerResult;
+import biouml.plugins.servermonitor.ServerMonitorConfig;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests {@link AsyncProfilerWrapper}'s child-process handling with a fake
+ * profiler binary (a shell script standing in for asprof), without touching a
+ * real JVM or the profiler agent:
+ *
+ * <ul>
+ *   <li>a clean run exits promptly and is reported successful;</li>
+ *   <li>when the "profiler" hangs past the timeout, the wrapper bounds the
+ *       wait, destroys the child, and does NOT block the caller indefinitely
+ *       — the regression behind the ict "stop timed out after 30s" spam,
+ *       where a hung process held the output pipe and blocked the reader;</li>
+ *   <li>a non-zero exit is reported as a failed result;</li>
+ *   <li>the pre-run guard skips {@code asprof stop} entirely when no session
+ *       is active, so an idle monitoring cycle pays no stop wait (the ict
+ *       log-spam amplifier: every 60s cycle ran a stop that hung 30s).</li>
+ * </ul>
+ *
+ * <p>The fake binary's script location selects its behavior via argv[1]:
+ * {@code stop} → sleep forever (the agent-stuck symptom); {@code -d N ...}
+ * → sleep 0.2s then exit 0 and create the output file (a clean run);
+ * {@code -c 1} → sleep 0.2s then exit 1 (a failed run).
+ */
+public class TestAsyncProfilerWrapper extends junit.framework.TestCase
+{
+    private File tmpDir;
+    private ServerMonitorConfig config;
+
+    public TestAsyncProfilerWrapper(String name)
+    {
+        super(name);
+    }
+
+    public static Test suite()
+    {
+        TestSuite suite = new TestSuite(TestAsyncProfilerWrapper.class.getName());
+        suite.addTest(new TestAsyncProfilerWrapper("testCleanRunSucceeds"));
+        suite.addTest(new TestAsyncProfilerWrapper("testHungProfilerIsBoundedAndDestroyed"));
+        suite.addTest(new TestAsyncProfilerWrapper("testNonZeroExitReportedAsFailure"));
+        suite.addTest(new TestAsyncProfilerWrapper("testStopSkippedWhenNoSessionActive"));
+        return suite;
+    }
+
+    @Override
+    protected void setUp() throws Exception
+    {
+        super.setUp();
+        tmpDir = Files.createTempDirectory("asprofwrapper-test").toFile();
+        config = new ServerMonitorConfig();
+        config.set(ServerMonitorConfig.PROFILER_DIR, tmpDir.getAbsolutePath());
+    }
+
+    @Override
+    protected void tearDown() throws Exception
+    {
+        deleteRecursively(tmpDir);
+        super.tearDown();
+    }
+
+    // --------------------------------------------------------------- tests
+
+    /** A fast, well-behaved profiler run must be reported as successful. */
+    public void testCleanRunSucceeds()
+    {
+        AsyncProfilerWrapper wrapper = makeWrapperWithFake("clean");
+        ProfilerResult result = wrapper.start(new long[0], "collapsed");
+
+        assertTrue("expected successful profile, got: " + result.getError(),
+                result.isSuccess());
+        assertNotNull("expected an output path on success",
+                result.getOutputPath());
+        assertTrue("expected output file to exist: " + result.getOutputPath(),
+                new File(result.getOutputPath()).exists());
+        // runProfiler clears the in-progress marker in a finally block.
+        assertEquals("expected stopped status after run",
+                "stopped", wrapper.getProfileStatus());
+    }
+
+    /**
+     * A profiler that hangs must not hang the wrapper: the wait is bounded,
+     * the child is destroyed, and a failed result is returned. We use the
+     * test-only timeout override to shrink the bound to a few seconds so the
+     * hang path is exercised quickly; the property under test is that the
+     * bound is honored and the caller is not blocked indefinitely (the old
+     * failure mode was a blocked output reader / an unbounded stop wait).
+     */
+    public void testHungProfilerIsBoundedAndDestroyed() throws Exception
+    {
+        AsyncProfilerWrapper wrapper = makeWrapperWithFake("hung");
+        config.set(ServerMonitorConfig.PROFILE_DURATION, 2);
+        wrapper.setTestRunTimeout(3); // shrink the run timeout to ~3s for the test
+
+        long start = System.currentTimeMillis();
+        ProfilerResult result = wrapper.start(new long[0], "collapsed");
+        long elapsedMs = System.currentTimeMillis() - start;
+
+        assertFalse("expected failed profile, got success at "
+                + result.getOutputPath(), result.isSuccess());
+        assertTrue("wrapper blocked too long: " + elapsedMs + "ms "
+                + "(should be bounded by ~3s test timeout, not hang)",
+                elapsedMs < 15000);
+        // The hung child must have been destroyed, not left running.
+        assertEquals("expected stopped status after timeout",
+                "stopped", wrapper.getProfileStatus());
+    }
+
+    /** A profiler that exits non-zero is reported as a failed result. */
+    public void testNonZeroExitReportedAsFailure()
+    {
+        AsyncProfilerWrapper wrapper = makeWrapperWithFake("fail");
+        ProfilerResult result = wrapper.start(new long[0], "collapsed");
+
+        assertFalse("expected failed profile", result.isSuccess());
+        assertNotNull("expected an error message", result.getError());
+    }
+
+    /**
+     * When no profiling session is active, start() must not invoke
+     * {@code asprof stop} at all. The fake binary records every invocation in
+     * a marker file; the idle path writes nothing there, while a run always
+     * writes to the output file — so the absence of the marker (with the
+     * output present) proves stop was skipped.
+     */
+    public void testStopSkippedWhenNoSessionActive()
+    {
+        AsyncProfilerWrapper wrapper = makeWrapperWithFake("clean");
+        ProfilerResult result = wrapper.start(new long[0], "collapsed");
+
+        assertTrue("expected successful profile, got: " + result.getError(),
+                result.isSuccess());
+        File stopMarker = new File(tmpDir, "stop_invoked");
+        assertFalse("expected stop to be skipped when no session is active, "
+                + "but the fake profiler recorded a stop invocation",
+                stopMarker.exists());
+    }
+
+    // ----------------------------------------------------------------- utils
+
+    /**
+     * Build a wrapper whose configured profiler binary is a fake asprof shell
+     * script whose behavior is selected by {@code mode}:
+     * clean → fast success; hung → sleeps past the timeout; fail → exit 1.
+     */
+    private AsyncProfilerWrapper makeWrapperWithFake(String mode)
+    {
+        File binDir = new File(tmpDir, "fake-asprof");
+        assertTrue(binDir.mkdirs());
+        File script = new File(binDir, "asprof");
+        try {
+            Files.write(script.toPath(), fakeProfilerScript(mode).getBytes("UTF-8"));
+        } catch (java.io.IOException e) {
+            fail("could not write fake profiler script: " + e);
+        }
+        assertTrue("script must be executable", script.setExecutable(true));
+        config.set(ServerMonitorConfig.PROFILER_PATH, script.getAbsolutePath());
+        AsyncProfilerWrapper wrapper = new AsyncProfilerWrapper(config);
+        assertTrue("expected fake profiler to be available", wrapper.init());
+        return wrapper;
+    }
+
+    /**
+     * The fake profiler script. Its first argument distinguishes a {@code stop}
+     * invocation (sleeps forever — simulating the stuck agent) from a run
+     * (first arg {@code -d} or {@code -c}):
+     * <pre>
+     *   stop [pid]      → record marker, sleep 600 (agent stuck)
+     *   -d N -f F ...   → sleep 0.2, create F, exit 0          (mode: clean)
+     *   -d N -f F ...   → sleep 0.2, exit 1                    (mode: fail)
+     *   -c 1 [pid]      → sleep 0.2, exit 1                    (any mode)
+     * </pre>
+     */
+    private String fakeProfilerScript(String mode)
+    {
+        return "#!/bin/sh\n"
+            + "MARKER=\"" + tmpDir.getAbsolutePath() + "/stop_invoked\"\n"
+            + "if [ \"$1\" = \"stop\" ]; then\n"
+            + "  touch \"$MARKER\"\n"
+            + "  sleep 600\n"
+            + "  exit 0\n"
+            + "fi\n"
+            + "if [ \"$1\" = \"-c\" ]; then\n"
+            + "  sleep 0.2\n"
+            + "  exit 1\n"
+            + "fi\n"
+            + "# a run: -d <N> -f <path> ...\n"
+            + "F=\"\"\n"
+            + "while [ $# -gt 0 ]; do\n"
+            + "  if [ \"$1\" = \"-f\" ]; then shift; F=\"$1\"; fi\n"
+            + "  shift\n"
+            + "done\n"
+            + "sleep 0.2\n"
+            + "case \"" + mode + "\" in\n"
+            + "  hung) sleep 600 ;;\n"
+            + "  clean) [ -n \"$F\" ] && touch \"$F\"; exit 0 ;;\n"
+            + "  fail) exit 1 ;;\n"
+            + "esac\n";
+    }
+
+    private static void deleteRecursively(File f)
+    {
+        if (f == null || !f.exists()) return;
+        File[] children = f.listFiles();
+        if (children != null) {
+            for (File c : children) deleteRecursively(c);
+        }
+        f.delete();
+    }
+}

--- a/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
@@ -9,7 +9,6 @@ import junit.framework.TestSuite;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * Tests {@link AsyncProfilerWrapper}'s child-process handling with a fake
@@ -19,19 +18,23 @@ import java.nio.file.Path;
  * <ul>
  *   <li>a clean run exits promptly and is reported successful;</li>
  *   <li>when the "profiler" hangs past the timeout, the wrapper bounds the
- *       wait, destroys the child, and does NOT block the caller indefinitely
- *       — the regression behind the ict "stop timed out after 30s" spam,
- *       where a hung process held the output pipe and blocked the reader;</li>
+ *       wait, destroys the child <em>and its descendants</em>, and does NOT
+ *       block the caller indefinitely — the regression behind the ict
+ *       "stop timed out after 30s" spam, where a hung process held the output
+ *       pipe and blocked the reader;</li>
  *   <li>a non-zero exit is reported as a failed result;</li>
  *   <li>the pre-run guard skips {@code asprof stop} entirely when no session
  *       is active, so an idle monitoring cycle pays no stop wait (the ict
  *       log-spam amplifier: every 60s cycle ran a stop that hung 30s).</li>
  * </ul>
  *
- * <p>The fake binary's script location selects its behavior via argv[1]:
- * {@code stop} → sleep forever (the agent-stuck symptom); {@code -d N ...}
- * → sleep 0.2s then exit 0 and create the output file (a clean run);
- * {@code -c 1} → sleep 0.2s then exit 1 (a failed run).
+ * <p>The fake binary's first argument selects its behavior:
+ * {@code stop} → sleep forever (the agent-stuck symptom); {@code -d ...} →
+ * sleep 0.2s then exit 0 and create the output file (a clean run); {@code -c
+ * 1} → sleep 0.2s then exit 1 (a failed run). The hanging path uses
+ * {@code exec sleep} so there is exactly one process to clean up (no orphaned
+ * grandchild that would keep the output pipe open and mask a cleanup
+ * failure).
  */
 public class TestAsyncProfilerWrapper extends junit.framework.TestCase
 {
@@ -90,11 +93,13 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
 
     /**
      * A profiler that hangs must not hang the wrapper: the wait is bounded,
-     * the child is destroyed, and a failed result is returned. We use the
-     * test-only timeout override to shrink the bound to a few seconds so the
-     * hang path is exercised quickly; the property under test is that the
-     * bound is honored and the caller is not blocked indefinitely (the old
-     * failure mode was a blocked output reader / an unbounded stop wait).
+     * the child (and its descendants) is destroyed, and a failed result is
+     * returned. We use the test-only timeout override to shrink the bound to a
+     * few seconds so the hang path is exercised quickly. The property under
+     * test is that the bound is honored, the caller is not blocked
+     * indefinitely (the old failure mode was a blocked output reader / an
+     * unbounded stop wait), and the hung process is actually torn down — not
+     * left behind as an orphan.
      */
     public void testHungProfilerIsBoundedAndDestroyed() throws Exception
     {
@@ -108,12 +113,25 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
 
         assertFalse("expected failed profile, got success at "
                 + result.getOutputPath(), result.isSuccess());
+        // Intended bound: ~3s timeout + ~5s kill-confirm (+ small overhead).
+        // 12s allows CI jitter while still catching a regression that lets the
+        // call run for a minute (the old unbounded behavior).
         assertTrue("wrapper blocked too long: " + elapsedMs + "ms "
-                + "(should be bounded by ~3s test timeout, not hang)",
-                elapsedMs < 15000);
-        // The hung child must have been destroyed, not left running.
-        assertEquals("expected stopped status after timeout",
-                "stopped", wrapper.getProfileStatus());
+                + "(should be bounded by ~3s timeout + 5s kill-confirm)",
+                elapsedMs < 12000);
+
+        // The fake hang is `exec sleep 600` — exactly one process. It must be
+        // gone shortly after start() returns; a leak here would mean the
+        // wrapper failed to destroy the hung child (or its tree).
+        String marker = "asprof-test-hung-" + tmpDir.getName();
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            if (listPidsRunningMarker(marker).isEmpty()) break;
+            Thread.sleep(100);
+        }
+        java.util.List<String> leftover = listPidsRunningMarker(marker);
+        assertTrue("expected the hung fake profiler process to be destroyed, "
+                + "but found still running: " + leftover, leftover.isEmpty());
     }
 
     /** A profiler that exits non-zero is reported as a failed result. */
@@ -128,10 +146,10 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
 
     /**
      * When no profiling session is active, start() must not invoke
-     * {@code asprof stop} at all. The fake binary records every invocation in
-     * a marker file; the idle path writes nothing there, while a run always
-     * writes to the output file — so the absence of the marker (with the
-     * output present) proves stop was skipped.
+     * {@code asprof stop} at all. The fake binary records every stop
+     * invocation in a marker file; the idle path writes nothing there, while
+     * a run always writes to the output file — so the absence of the marker
+     * (with the output present) proves stop was skipped.
      */
     public void testStopSkippedWhenNoSessionActive()
     {
@@ -171,23 +189,29 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
     }
 
     /**
-     * The fake profiler script. Its first argument distinguishes a {@code stop}
-     * invocation (sleeps forever — simulating the stuck agent) from a run
-     * (first arg {@code -d} or {@code -c}):
+     * The fake profiler script. Its first argument distinguishes a
+     * {@code stop} invocation (sleeps forever — simulating the stuck agent)
+     * from a run (first arg {@code -d} or {@code -c}):
      * <pre>
-     *   stop [pid]      → record marker, sleep 600 (agent stuck)
+     *   stop [pid]      → record marker, exec sleep 600 (agent stuck)
      *   -d N -f F ...   → sleep 0.2, create F, exit 0          (mode: clean)
+     *   -d N -f F ...   → exec sleep 600 (no exit)             (mode: hung)
      *   -d N -f F ...   → sleep 0.2, exit 1                    (mode: fail)
      *   -c 1 [pid]      → sleep 0.2, exit 1                    (any mode)
      * </pre>
+     *
+     * The hanging path uses {@code exec} so the shell is replaced by the
+     * sleeper — a single process — meaning the wrapper's process-tree teardown
+     * is what must reclaim it, and the test can detect a leak unambiguously.
      */
     private String fakeProfilerScript(String mode)
     {
         return "#!/bin/sh\n"
             + "MARKER=\"" + tmpDir.getAbsolutePath() + "/stop_invoked\"\n"
+            + "HANGMARKER=\"asprof-test-hung-" + tmpDir.getName() + "\"\n"
             + "if [ \"$1\" = \"stop\" ]; then\n"
             + "  touch \"$MARKER\"\n"
-            + "  sleep 600\n"
+            + "  exec sleep 600\n"
             + "  exit 0\n"
             + "fi\n"
             + "if [ \"$1\" = \"-c\" ]; then\n"
@@ -202,10 +226,36 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
             + "done\n"
             + "sleep 0.2\n"
             + "case \"" + mode + "\" in\n"
-            + "  hung) sleep 600 ;;\n"
+            + "  hung) exec sleep 600 ;;\n"
             + "  clean) [ -n \"$F\" ] && touch \"$F\"; exit 0 ;;\n"
             + "  fail) exit 1 ;;\n"
             + "esac\n";
+    }
+
+    /**
+     * Return the PIDs of processes on this host whose command line contains
+     * the given marker string. Used to confirm a hung fake-profiler process
+     * was actually destroyed (the wrapper's process-tree teardown) rather
+     * than merely that {@code start()} returned.
+     */
+    private java.util.List<String> listPidsRunningMarker(String marker) throws Exception
+    {
+        java.util.List<String> pids = new java.util.ArrayList<>();
+        File procDir = new File("/proc");
+        File[] entries = procDir.listFiles();
+        if (entries == null) return pids;
+        for (File e : entries) {
+            String name = e.getName();
+            if (name.isEmpty() || !name.chars().allMatch(Character::isDigit)) continue;
+            File cmdline = new File(e, "cmdline");
+            if (!cmdline.exists()) continue;
+            byte[] data = Files.readAllBytes(cmdline.toPath());
+            String cmd = new String(data, "UTF-8").replace('\u0000', ' ').trim();
+            if (cmd.contains(marker)) {
+                pids.add(name);
+            }
+        }
+        return pids;
     }
 
     private static void deleteRecursively(File f)

--- a/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
@@ -51,6 +51,7 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
         TestSuite suite = new TestSuite(TestAsyncProfilerWrapper.class.getName());
         suite.addTest(new TestAsyncProfilerWrapper("testCleanRunSucceeds"));
         suite.addTest(new TestAsyncProfilerWrapper("testHungProfilerIsBoundedAndDestroyed"));
+        suite.addTest(new TestAsyncProfilerWrapper("testHungProcessTreeIsBoundedAndDestroyed"));
         suite.addTest(new TestAsyncProfilerWrapper("testNonZeroExitReportedAsFailure"));
         suite.addTest(new TestAsyncProfilerWrapper("testStopSkippedWhenNoSessionActive"));
         return suite;
@@ -134,6 +135,46 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
                 + "but found still running: " + leftover, leftover.isEmpty());
     }
 
+    /**
+     * A profiler whose hang is a real process tree (a shell wrapper that
+     * spawns a child and waits for it, rather than {@code exec}-ing it) must
+     * have the WHOLE tree torn down — not just the direct child. This is the
+     * scenario the earlier review flagged: a shell's child (e.g. {@code sleep})
+     * survives a plain {@code destroyForcibly()} of the shell, keeps the output
+     * pipe open, and leaks. We assert both the wrapper process and its child
+     * disappear.
+     */
+    public void testHungProcessTreeIsBoundedAndDestroyed() throws Exception
+    {
+        AsyncProfilerWrapper wrapper = makeWrapperWithFake("tree");
+        config.set(ServerMonitorConfig.PROFILE_DURATION, 2);
+        wrapper.setTestRunTimeout(3);
+
+        long start = System.currentTimeMillis();
+        ProfilerResult result = wrapper.start(new long[0], "collapsed");
+        long elapsedMs = System.currentTimeMillis() - start;
+
+        assertFalse("expected failed profile, got success at "
+                + result.getOutputPath(), result.isSuccess());
+        assertTrue("wrapper blocked too long: " + elapsedMs + "ms "
+                + "(should be bounded by ~3s timeout + 5s kill-confirm)",
+                elapsedMs < 12000);
+
+        // The hang is a shell wrapper (parent) plus a `sleep 600` child. Both
+        // must be gone; a leak of the child means the process-tree teardown
+        // (descendants() kill) did not work.
+        String marker = "asprof-test-tree-" + tmpDir.getName();
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            if (listPidsRunningMarker(marker).isEmpty()) break;
+            Thread.sleep(100);
+        }
+        java.util.List<String> leftover = listPidsRunningMarker(marker);
+        assertTrue("expected the whole hung fake profiler process tree "
+                + "(wrapper + child) to be destroyed, but found still running: "
+                + leftover, leftover.isEmpty());
+    }
+
     /** A profiler that exits non-zero is reported as a failed result. */
     public void testNonZeroExitReportedAsFailure()
     {
@@ -197,18 +238,21 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
      *   -d N -f F ...   → sleep 0.2, create F, exit 0          (mode: clean)
      *   -d N -f F ...   → exec sleep 600 (no exit)             (mode: hung)
      *   -d N -f F ...   → sleep 0.2, exit 1                    (mode: fail)
+     *   -d N -f F ...   → spawn child + wait (a process tree) (mode: tree)
      *   -c 1 [pid]      → sleep 0.2, exit 1                    (any mode)
      * </pre>
      *
-     * The hanging path uses {@code exec} so the shell is replaced by the
-     * sleeper — a single process — meaning the wrapper's process-tree teardown
-     * is what must reclaim it, and the test can detect a leak unambiguously.
+     * The {@code hung} path uses {@code exec} so the shell is replaced by the
+     * sleeper — a single process (tests direct-child teardown). The {@code tree}
+     * path deliberately keeps the shell alive and spawns a {@code sleep 600}
+     * child, so the wrapper's process-<em>tree</em> teardown (the
+     * {@code descendants()} kill) is what must reclaim both — a plain
+     * {@code destroyForcibly()} of the shell alone would orphan the child.
      */
     private String fakeProfilerScript(String mode)
     {
         return "#!/bin/sh\n"
             + "MARKER=\"" + tmpDir.getAbsolutePath() + "/stop_invoked\"\n"
-            + "HANGMARKER=\"asprof-test-hung-" + tmpDir.getName() + "\"\n"
             + "if [ \"$1\" = \"stop\" ]; then\n"
             + "  touch \"$MARKER\"\n"
             + "  exec sleep 600\n"
@@ -225,8 +269,10 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
             + "  shift\n"
             + "done\n"
             + "sleep 0.2\n"
+            + "TREE_MARKER=\"asprof-test-tree-" + tmpDir.getName() + "\"\n"
             + "case \"" + mode + "\" in\n"
             + "  hung) exec sleep 600 ;;\n"
+            + "  tree) TREE_MARKER=\"$TREE_MARKER\" /bin/sh -c 'sleep 600 \"$TREE_MARKER\"' & wait ;;\n"
             + "  clean) [ -n \"$F\" ] && touch \"$F\"; exit 0 ;;\n"
             + "  fail) exit 1 ;;\n"
             + "esac\n";

--- a/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
+++ b/src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java
@@ -143,9 +143,10 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
      * survives a plain {@code destroyForcibly()} of the shell, keeps the output
      * pipe open, and leaks.
      *
-     * <p>The fake records the child's PID in a file, so the test checks
-     * {@code /proc/<childPid>} directly — a deterministic identification of the
-     * process the test itself created, rather than a command-line scan.
+     * <p>The fake records the wrapper's own PID and the child's PID in a file,
+     * so the test checks {@code /proc/<pid>} for both — a deterministic
+     * identification of the processes the test itself created, rather than a
+     * command-line scan.
      */
     public void testHungProcessTreeIsBoundedAndDestroyed() throws Exception
     {
@@ -163,23 +164,32 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
                 + "(should be bounded by ~3s timeout + 5s kill-confirm)",
                 elapsedMs < 12000);
 
-        // The fake spawned a real `sleep 600` child and recorded its PID.
-        // That child (the shell wrapper's descendant) must be gone; a leak
+        // The fake spawned a real `sleep 600` child and recorded the wrapper's
+        // own PID plus the child's PID. Both must be gone; a leak of the child
         // means the process-tree teardown (descendants() kill) did not work.
-        File pidFile = new File(tmpDir, "tree_child.pid");
-        assertTrue("expected the fake profiler to record its child PID in "
+        File pidFile = new File(tmpDir, "tree_pids");
+        assertTrue("expected the fake profiler to record its PIDs in "
                 + pidFile, pidFile.exists());
-        long childPid = Long.parseLong(new String(Files.readAllBytes(pidFile.toPath())).trim());
+        String[] lines = new String(Files.readAllBytes(pidFile.toPath())).trim().split("\\R");
+        assertTrue("expected two recorded PIDs, got: " + java.util.Arrays.toString(lines),
+                lines.length == 2);
+        long wrapperPid = Long.parseLong(lines[0].trim());
+        long childPid = Long.parseLong(lines[1].trim());
+        assertTrue("expected a plausible wrapper PID, got " + wrapperPid, wrapperPid > 0);
         assertTrue("expected a plausible child PID, got " + childPid, childPid > 0);
 
-        File childProc = new File("/proc/" + childPid);
         long deadline = System.currentTimeMillis() + 5000;
-        while (childProc.exists() && System.currentTimeMillis() < deadline) {
+        while (System.currentTimeMillis() < deadline) {
+            if (!new File("/proc/" + wrapperPid).exists()
+                    && !new File("/proc/" + childPid).exists()) break;
             Thread.sleep(100);
         }
-        assertFalse("expected the hung fake profiler's child (PID " + childPid
-                + ") to be destroyed by the process-tree teardown, but "
-                + "/proc/" + childPid + " still exists", childProc.exists());
+        boolean wrapperAlive = new File("/proc/" + wrapperPid).exists();
+        boolean childAlive = new File("/proc/" + childPid).exists();
+        assertFalse("expected the hung fake profiler tree to be destroyed, but "
+                + "wrapper PID " + wrapperPid + " alive=" + wrapperAlive
+                + ", child PID " + childPid + " alive=" + childAlive,
+                wrapperAlive || childAlive);
     }
 
     /** A profiler that exits non-zero is reported as a failed result. */
@@ -276,10 +286,10 @@ public class TestAsyncProfilerWrapper extends junit.framework.TestCase
             + "  shift\n"
             + "done\n"
             + "sleep 0.2\n"
-            + "TREE_PID_FILE=\"" + tmpDir.getAbsolutePath() + "/tree_child.pid\"\n"
+            + "TREE_PID_FILE=\"" + tmpDir.getAbsolutePath() + "/tree_pids\"\n"
             + "case \"" + mode + "\" in\n"
             + "  hung) exec sleep 600 ;;\n"
-            + "  tree) sleep 600 & echo $! > \"$TREE_PID_FILE\"; wait ;;\n"
+            + "  tree) echo $$ > \"$TREE_PID_FILE\"; sleep 600 & echo $! >> \"$TREE_PID_FILE\"; wait ;;\n"
             + "  clean) [ -n \"$F\" ] && touch \"$F\"; exit 0 ;;\n"
             + "  fail) exit 1 ;;\n"
             + "esac\n";


### PR DESCRIPTION
## Problem

The ict server log was clogged with ~2,000 lines of:

```
WARNING: AsyncProfilerWrapper: stop timed out after 30s, destroying process
```

Root cause (three defects combining):

1. **Stuck async-profiler agent.** A prior profiler CLI was SIGKILLed mid-teardown, leaving the in-JVM agent active (same class of bug fixed on strange_gx in #28). With the agent stuck, every `asprof stop` hangs until killed.
2. **Pre-run stop ran on every run.** `runProfiler` unconditionally called `stop()` before each `asprof -d`. The monitoring loop checks every 60s, so each cycle paid the full 30s stop timeout → destroy → warning.
3. **Blocking inline stdout read.** `runProfiler` read the child's stdout to EOF *before* the timeout was even checked. A hung child keeps its pipe open, so the reader could block forever (the timeout never reached); >64KB of output would also deadlock the child.

## Fix

- **Skip the pre-run `stop()` when no session is in progress** (`activeProfileOutputPath == null`). The flag is set/cleared around the synchronous `asprof -d` run. A genuinely active or interrupted run still gets the bounded stop + lingering-process fallback.
- **Bounded, non-blocking child I/O.** Output is drained on a daemon thread (pipe never fills, reader never blocks the caller); only the last 16KB are kept for failure diagnostics. A single bounded `waitForProcessExit()` (timeout → `destroyForcibly` → bounded confirm) now serves both the run and `stop()`.
- `stop()` preserves the interrupt status on interruption.

**Net effect:** the log spam stops. When the agent is genuinely stuck, runs fail fast with the real async-profiler error instead of a 30s timeout, until the agent is cleared (container restart or a working `asprof stop`) — no in-process fix can release a stuck agent while it's stuck.

## Tests

New `src/biouml/plugins/servermonitor/_test/TestAsyncProfilerWrapper.java` (fake-`asprof` shell script, no real JVM/agent touched):
- clean run succeeds and output file is created
- hung run is bounded by the timeout, child destroyed, failed result returned (uses a test-only timeout hook)
- non-zero exit reported as failure
- `stop` is skipped entirely when no session is active

`mvn -pl src test` → 762 tests pass; `cd src && ant compile` → BUILD SUCCESSFUL.

## Note on deployment

The stuck agent on ict will not clear until the `bioumlweb` container is restarted. This PR stops the spam and the 30s-per-cycle delays; a restart is still required to get profiling working again.