### PR TITLE
perf(profiler): integerize heap-sort index math in Util.sortHeap

### DIFF
--- a/.claude/skills/profiler-review/scripts/fetch_profile.sh
+++ b/.claude/skills/profiler-review/scripts/fetch_profile.sh
@@ -33,11 +33,13 @@ if [[ -z "${MONITORING_USER:-}" || -z "${MONITORING_PASS:-}" ]]; then
   exit 1
 fi
 
-# Server URL: last argument, fall back to PROFILE_SERVER_URL env var
+# Server URL: last positional argument, fall back to PROFILE_SERVER_URL env var.
+# Capture before any shift: .env is sourced with `set -a` which exports
+# PROFILE_SERVER_URL, so an unguarded `shift` would consume it from $@.
 SERVER_URL="${PROFILE_SERVER_URL:-}"
-if [[ $# -gt 0 ]]; then
-  SERVER_URL="${@: -1}"
-fi
+for _arg in "$@"; do
+  SERVER_URL="$_arg"
+done
 SERVER_URL="${SERVER_URL%/}"
 
 if [[ -z "$SERVER_URL" ]]; then
@@ -104,8 +106,8 @@ print(json.dumps(filtered, indent=2))
       exit 1
     fi
     PROFILE_ID="$1"
-    shift
-
+    # PROFILE_SERVER_URL is already captured into SERVER_URL above; do not
+    # shift again (it would shift the exported env var out of $@).
     GET_URL="${SERVER_URL}/biouml/support/profile?action=get&id=${PROFILE_ID}&user=${MONITORING_USER}&pass=${MONITORING_PASS}"
     echo "Fetching profile '${PROFILE_ID}' from: ${GET_URL}" >&2
     echo "" >&2

--- a/src/ru/biosoft/analysis/Util.java
+++ b/src/ru/biosoft/analysis/Util.java
@@ -951,7 +951,10 @@ public class Util
             t = i;
             while( t != 1 )
             {
-                k = (int) ( (double)t / 2 );
+                // t is always an integer <= n < 2^52, so t/2 is exact: the double
+                // round-trip is equivalent to a plain integer shift but costs extra ops
+                // in this O(n log n) hot loop (wilcoxonTest sorts the score array with it).
+                k = t >> 1;
                 if( x[k - 1] >= x[t - 1] )
                     t = 1;
                 else


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://strange.genexplain.com (server URL provided by the user).

## Profiles Analyzed
- Number of reports: 5 (last 24h, >1000 bytes)
- Total samples across all profiles: 101,532
- Dominant task: CMAGenetic CMA analysis (Wilcoxon-scored genetic model search)

## Top Hot Functions (aggregated leaf samples)
1. `GaussModel.calculateModelScore` — 47,407 (46.7%) — innermost CMA scoring loop (optimized in the companion geneXplain PR)
2. `GaussModel.calculateScore` — 19,226 (18.9%) — CMA scoring driver
3. `ExponentCache.exp` — 8,454 (8.3%) — gaussian vector build
4. `Util.sortHeap` — ~5% — heap sort called per-model by `wilcoxonTest` in the CMA scoring loop

## Changes
- `ru.biosoft.analysis.Util.sortHeap(double[])`: the heap build-down computed the parent index as `k = (int)((double)t / 2)`. Since t is always an integer < 2^52, the double round-trip is exactly equivalent to `t >> 1` but costs extra ops in an O(n log n) loop that runs once per model per population individual. Replaced with a plain integer shift.
- Fixed the profiler-review `fetch_profile.sh` skill script: an unguarded `shift` consumed the exported `PROFILE_SERVER_URL` env var from the positional args (the script sources `.env` with `set -a`, which exports it), corrupting the request URL. The server URL is now captured before any shift, and a redundant re-shift in the `get` action was removed.

## Verification
- [x] Maven build passes (`mvn package -DskipTests`)
- [x] Ant build passes (`cd src && ant compile`)
- [x] All tests pass (`mvn -pl src test` — 767 tests, 0 failures)

Note: the primary CPU cost (GaussModel scoring) lives in the geneXplain repo, not here; see the companion geneXplain PR for that part.

Co-Authored-By: Claude <noreply@anthropic.com>