### PR TITLE
perf(profiler): avoid per-call HashSet/box allocations in CoordinateMapping.mapInterval

### DIFF
--- a/src/ru/biosoft/bsa/analysis/_test/CoordinateMappingTest.java
+++ b/src/ru/biosoft/bsa/analysis/_test/CoordinateMappingTest.java
@@ -1,0 +1,280 @@
+package ru.biosoft.bsa.analysis._test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import ru.biosoft.bsa.Interval;
+import ru.biosoft.bsa.analysis.maos.coord_mapping.CoordinateMapping;
+import junit.framework.TestCase;
+
+/**
+ * Tests the default {@link CoordinateMapping#mapInterval(Interval)} implementation.
+ *
+ * The contract under test: the returned {@link Collection} holds the <em>distinct</em>
+ * mapped positions (deduplicated), with unmapped positions (-1) skipped. Callers use the
+ * result only for emptiness checks and best/iterate scans, which are order- and
+ * dedup-insensitive — but the implementation still must return distinct values, so these
+ * tests assert both the set content and the result cardinality (which a mere set-equality
+ * check would not catch if duplicates were returned).
+ */
+public class CoordinateMappingTest extends TestCase
+{
+    // Identity mapping on [1, 10]: get(x) = x. For an identity mapping the mapped value
+    // (y - i = (from+i) - i) is the constant 'from', so the whole interval collapses to
+    // a single distinct value.
+    private static final CoordinateMapping IDENTITY = new CoordinateMapping()
+    {
+        @Override
+        public int get(int x)
+        {
+            return x >= 1 && x <= 10 ? x : -1;
+        }
+
+        @Override
+        public Interval getBounds()
+        {
+            return new Interval(1, 10);
+        }
+    };
+
+    // CONSTANT_TARGET: every position maps to the same target (get(x) = 1), so
+    // mapped = 1 - i varies with i, producing multiple distinct values. Exercises the
+    // 2+ distinct-value branch.
+    private static final CoordinateMapping CONSTANT_TARGET = new CoordinateMapping()
+    {
+        @Override
+        public int get(int x)
+        {
+            return x >= 1 && x <= 10 ? 1 : -1;
+        }
+
+        @Override
+        public Interval getBounds()
+        {
+            return new Interval(1, 10);
+        }
+    };
+
+    // Identity except x=3 and x=7 are unmapped (-1). Verifies that -1 positions are
+    // skipped without affecting the (constant) mapped value.
+    private static final CoordinateMapping WITH_GAPS = new CoordinateMapping()
+    {
+        @Override
+        public int get(int x)
+        {
+            if(x < 1 || x > 10) return -1;
+            if(x == 3 || x == 7) return -1;
+            return x;
+        }
+
+        @Override
+        public Interval getBounds()
+        {
+            return new Interval(1, 10);
+        }
+    };
+
+    // A non-identity mapping whose mapped values are genuinely distinct, with a
+    // deliberate duplicate (i=0 and i=2 both map to 2) to exercise deduplication.
+    private static final CoordinateMapping MULTI_DISTINCT = new CoordinateMapping()
+    {
+        @Override
+        public int get(int x)
+        {
+            return x >= 1 && x <= 10 ? x + (x % 2) : -1; // even x -> x, odd x -> x+1
+        }
+
+        @Override
+        public Interval getBounds()
+        {
+            return new Interval(1, 10);
+        }
+    };
+
+    private static Set<Integer> toSet(Collection<Integer> c)
+    {
+        Set<Integer> s = new HashSet<>();
+        for( Integer i : c ) s.add(i);
+        return s;
+    }
+
+    public void testEmptyWhenAllUnmapped()
+    {
+        assertTrue(WITH_GAPS.mapInterval(new Interval(3, 3)).isEmpty());
+    }
+
+    public void testIdentitySinglePosition()
+    {
+        Collection<Integer> r = IDENTITY.mapInterval(new Interval(5, 5));
+        assertEquals(1, r.size());
+        assertTrue(r.contains(5));
+    }
+
+    public void testIdentityIntervalCollapsesToOne()
+    {
+        // mapped is constant (= from) for an identity mapping -> exactly one value.
+        Collection<Integer> r = IDENTITY.mapInterval(new Interval(2, 6));
+        assertEquals(1, r.size());
+        assertTrue(r.contains(2));
+    }
+
+    public void testLargeIntervalSingleDistinctValue()
+    {
+        // A long interval that still produces a single distinct value: must return
+        // exactly one element (this is the common case the allocation must not
+        // regress — the result size is the distinct count, not the interval length).
+        Collection<Integer> r = IDENTITY.mapInterval(new Interval(1, 10));
+        assertEquals(1, r.size());
+        assertTrue(r.contains(1));
+    }
+
+    public void testConstantTargetMultipleDistinct()
+    {
+        // get(x) = 1 for all x in [1,10]; mapped = 1 - i.
+        // Interval [2,4] -> i = 0,1,2 -> mapped = 1, 0, -1 -> 3 distinct.
+        Collection<Integer> r = CONSTANT_TARGET.mapInterval(new Interval(2, 4));
+        Set<Integer> expected = new HashSet<>();
+        expected.add(1); expected.add(0); expected.add(-1);
+        assertEquals(expected, toSet(r));
+        assertEquals(3, r.size()); // cardinality: no duplicates
+    }
+
+    public void testGapsSkipUnmapped()
+    {
+        // Interval [2,4] covers x = 2,3,4; x=3 is unmapped (-1). mapped is still the
+        // constant 2 for the identity positions -> a single value {2}, gaps skipped.
+        Collection<Integer> r = WITH_GAPS.mapInterval(new Interval(2, 4));
+        assertEquals(1, r.size());
+        assertTrue(r.contains(2));
+    }
+
+    public void testAgainstBruteForceReference()
+    {
+        // Brute-force reference: the distinct set of (get(from+i) - i) over the
+        // interval, skipping get == -1. This is independent of the
+        // implementation's dedup/growth logic, so it settles correctness.
+        for( int a = 1; a <= 10; a++ )
+            for( int b = a; b <= 10; b++ )
+            {
+                Set<Integer> expected = new HashSet<>();
+                for( int i = 0; i < b - a + 1; i++ )
+                {
+                    int y = MULTI_DISTINCT.get( a + i );
+                    if( y != -1 )
+                        expected.add( y - i );
+                }
+                Collection<Integer> r = MULTI_DISTINCT.mapInterval( new Interval( a, b ) );
+                assertEquals( "content for [" + a + "," + b + "]", expected, toSet( r ) );
+                assertEquals( "cardinality for [" + a + "," + b + "]", expected.size(), r.size() );
+            }
+    }
+
+    public void testManyDistinctGrowsBuffer()
+    {
+        // CONSTANT_TARGET: mapped = 1 - i, all distinct. Interval [1,6] ->
+        // mapped = 1,0,-1,-2,-3,-4 (6 distinct), exercising the int[] growth path
+        // (capacity 2 -> 4 -> 8) and confirming no value is lost during growth.
+        Collection<Integer> r = CONSTANT_TARGET.mapInterval(new Interval(1, 6));
+        Set<Integer> expected = new HashSet<>();
+        for( int v = 1; v >= -4; v-- ) expected.add( v );
+        assertEquals(expected, toSet(r));
+        assertEquals(6, r.size());
+    }
+
+    // Fixed-table mapping used for adversarial cases: it produces repeated values,
+    // long runs of duplicates, irregular -1 gaps, and many distinct values, all of
+    // which the linear-scan + growth + dedup logic must handle correctly. The table
+    // is defined over source coords 1..12; out-of-range coords map to -1 (unmapped).
+    private static final int[] ADVERSARIAL_TABLE = {
+        0, // index 0 unused (source coords start at 1)
+        5, 5, 5, -1, 9, 9, -1, 3, 3, 3, 12, 12 // coords 1..12
+    };
+    private static final CoordinateMapping ADVERSARIAL = new CoordinateMapping()
+    {
+        @Override
+        public int get(int x)
+        {
+            return x >= 1 && x < ADVERSARIAL_TABLE.length ? ADVERSARIAL_TABLE[x] : -1;
+        }
+
+        @Override
+        public Interval getBounds()
+        {
+            return new Interval(1, 12);
+        }
+    };
+
+    private static Set<Integer> referenceDistinct(CoordinateMapping m, int from, int to)
+    {
+        Set<Integer> expected = new HashSet<>();
+        for( int i = 0; i <= to - from; i++ )
+        {
+            int y = m.get( from + i );
+            if( y != -1 )
+                expected.add( y - i );
+        }
+        return expected;
+    }
+
+    public void testAdversarialGapsAndDuplicates()
+    {
+        // ADVERSARIAL over [1,12] has repeated values (runs of 5, runs of 3, runs of
+        // 9), irregular -1 gaps (coords 4 and 7), and several distinct mapped values.
+        // Verify against the brute-force reference for both content and cardinality.
+        Collection<Integer> r = ADVERSARIAL.mapInterval( new Interval( 1, 12 ) );
+        Set<Integer> expected = referenceDistinct( ADVERSARIAL, 1, 12 );
+        assertEquals(expected, toSet(r));
+        assertEquals(expected.size(), r.size());
+    }
+
+    public void testAdversarialGrowDuplicateGrowDuplicate()
+    {
+        // Exercises the most complicated state: grow -> duplicate -> grow -> duplicate.
+        // With a table mapping, distinct mapped values appear interleaved with runs of
+        // duplicates that must be dropped after the buffer has already grown.
+        // Sweep every sub-interval of the adversarial mapping against the reference.
+        for( int a = 1; a <= 12; a++ )
+            for( int b = a; b <= 12; b++ )
+            {
+                Set<Integer> expected = referenceDistinct( ADVERSARIAL, a, b );
+                Collection<Integer> r = ADVERSARIAL.mapInterval( new Interval( a, b ) );
+                assertEquals("content for [" + a + "," + b + "]", expected, toSet(r));
+                assertEquals("cardinality for [" + a + "," + b + "]", expected.size(), r.size());
+            }
+    }
+
+    public void testManyDistinctThenDuplicatesAfterGrowth()
+    {
+        // A mapping whose mapped values (get(from+i) - i) first form a run of distinct
+        // values that force the buffer to grow past capacity 2 and 4, and then repeat
+        // earlier values, to confirm the dedup scan works once the buffer has grown.
+        // Desired mapped sequence for from=1, i=0..11: 1,2,3,4,5,6,1,2,3,4,5,1.
+        // Since mapped = get(1+i) - i, we need get(x) = mapped + i = mapped + (x-1).
+        int[] desiredMapped = {1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 1}; // i = 0..11
+        int[] table = new int[13]; // table[x] = get(x), x = 1..12
+        for( int x = 1; x <= 12; x++ )
+            table[x] = desiredMapped[x - 1] + (x - 1);
+        CoordinateMapping m = new CoordinateMapping()
+        {
+            @Override
+            public int get(int x)
+            {
+                return x >= 1 && x < table.length ? table[x] : -1;
+            }
+
+            @Override
+            public Interval getBounds()
+            {
+                return new Interval(1, 12);
+            }
+        };
+        // The distinct mapped values are {1,2,3,4,5,6}; the repeats (1,2,3,4,5,1)
+        // must be dropped even though the buffer has already grown.
+        Set<Integer> expected = new HashSet<>();
+        for( int v = 1; v <= 6; v++ ) expected.add( v );
+        Collection<Integer> r = m.mapInterval( new Interval( 1, 12 ) );
+        assertEquals(expected, toSet(r));
+        assertEquals(6, r.size()); // 6 distinct, 6 duplicates dropped
+    }
+}

--- a/src/ru/biosoft/bsa/analysis/maos/coord_mapping/CoordinateMapping.java
+++ b/src/ru/biosoft/bsa/analysis/maos/coord_mapping/CoordinateMapping.java
@@ -1,9 +1,8 @@
 package ru.biosoft.bsa.analysis.maos.coord_mapping;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 import ru.biosoft.bsa.Interval;
 
@@ -24,31 +23,76 @@ public interface CoordinateMapping
 
     default Collection<Integer> mapInterval(Interval interval)
     {
-        Set<Integer> result = Collections.emptySet();
-        for( int i = 0; i < interval.getLength(); i++ )
+        // Hot path of TFBS mutation analysis (called once per site position per
+        // model). Keep the first distinct mapped value in a primitive local and
+        // materialize an int[] buffer only when a second distinct value appears, so
+        // the common single-position case does no temporary allocation or boxing.
+        //
+        // Invariant once the buffer exists: values[0] is always 'first'. Because the
+        // first distinct value is always handled in the size==0 branch (before any
+        // buffer exists), a value equal to 'first' can only be a duplicate after that
+        // point, and it lives at values[0] -- so the linear duplicate scan must start
+        // at j=0, NOT j=1 (a j=1 scan would let the first value re-enter as a new
+        // distinct value). The distinct count is bounded by the number of
+        // constant-offset segments in a MappingByVCF (each segment contributes at most
+        // one distinct mapped value), which is small -- not by the interval length --
+        // so the linear scan stays cheap. Callers consume the (deduplicated) result
+        // only for emptiness checks and iterate/best scans, which need no Set semantics.
+        int length = interval.getLength();
+        int from = interval.getFrom();
+        int[] values = null;
+        int first = 0;
+        int size = 0;
+        for( int i = 0; i < length; i++ )
         {
-            int y = get( interval.getFrom() + i );
+            int y = get( from + i );
             if( y == -1 )
                 continue;
             int mapped = y - i;
-            if(result.isEmpty())
+            if( size == 0 )
             {
-                result = Collections.singleton( mapped );
+                first = mapped;
+                size = 1;
+                continue;
             }
-            else
+            if( values == null )
             {
-                if(result.size() == 1)
+                // Second distinct value: materialize the primitive buffer. Capacity
+                // tracks the distinct count, never the interval length.
+                if( mapped == first )
+                    continue;
+                values = new int[2];
+                values[0] = first;
+                values[1] = mapped;
+                size = 2;
+                continue;
+            }
+            // Linear membership test. Must scan from j=0: values[0] is 'first' and a
+            // later value equal to 'first' is a duplicate, not a new distinct value.
+            boolean found = false;
+            for( int j = 0; j < size; j++ )
+                if( values[j] == mapped )
                 {
-                    if(!result.contains( mapped ))
-                    {
-                        result = new HashSet<>(result);
-                        result.add(mapped);
-                    }
+                    found = true;
+                    break;
                 }
-                else
-                    result.add(mapped);
+            if( found )
+                continue;
+            if( size == values.length )
+            {
+                int[] grown = new int[values.length * 2];
+                System.arraycopy( values, 0, grown, 0, size );
+                values = grown;
             }
+            values[size++] = mapped;
         }
+        if( size == 0 )
+            return Collections.emptySet();
+        if( size == 1 )
+            return Collections.singleton( first );
+        Collection<Integer> result = new ArrayList<>( size );
+        for( int j = 0; j < size; j++ )
+            result.add( values[j] );
         return result;
     }
 }


### PR DESCRIPTION
Optimizations based on async-profiler analysis from https://strange.genexplain.com (the server URL provided by the user).

## Profiles Analyzed
- Number of reports: 25 collapsed profiles (single triggered task, ~24 windows of ~30s each)
- Time range: last 24 hours
- Total samples across all profiles: 296,472

## Top Hot Functions
1. GaussModel.calculateModelScore — 126,910 samples (42.8%) — already buffer-optimized on the server (primitive mirrors + reused top-K buffers); no further in-repo win.
2. GaussModel.calculateScore — 66,677 samples (22.5%) — same; already optimized.
3. CoordinateMapping.mapInterval — ~30,000 samples cumulative (10.1%) — **optimized in this PR**. Called once per site position per model in CompareTFBSMutations.maxSiteLoss; the old default implementation allocated a Collections.emptySet(), a boxed Integer for the singleton, and a HashSet<Integer> per distinct mapped value on every call.
4. MatchSiteModel.getCoreScore / WeightMatrixModel.getScore / SequenceSupport.getLetterCodeAt — ~22k / ~17k / ~8k samples — sequence-letter lookups feeding the TFBS mutation analysis; not changed here.

## Sub-process log
SLOW records during the window were hisat2/samtools/perl (external alignment work) from other tasks, not overlapping this task's in-JVM CPU profile — the in-JVM hot path (CMA + TFBS scoring) is the correct target.

## Changes
- Rewrote the default `CoordinateMapping.mapInterval` to accumulate distinct mapped positions in a small primitive `int[]` and return only the minimal boxed collection (emptySet / singleton / a few Integers). Eliminates the per-call HashSet<Integer> and the singleton boxing/contains/isEmpty calls. Result is used only for emptiness checks and best/iterate scans (order- and dedup-insensitive), so behavior is unchanged.
- Added `CoordinateMappingTest` covering the empty, singleton, gaps (-1 skip), and multi-distinct-value branches.

## Verification
- [x] Maven build passes (`mvn package -DskipTests`)
- [x] Ant build passes (`cd src && ant compile`)
- [x] All tests pass (`mvn -pl src test` — 777 tests, 0 failures)

Co-Authored-By: Claude <noreply@anthropic.com>